### PR TITLE
Upgrade from Vue2 to Vue3

### DIFF
--- a/00_setup/app.py
+++ b/00_setup/app.py
@@ -1,11 +1,11 @@
 from trame.app import get_server
-from trame.ui.vuetify import SinglePageLayout
+from trame.ui.vuetify3 import SinglePageLayout
 
 # -----------------------------------------------------------------------------
 # Get a server to work with
 # -----------------------------------------------------------------------------
 
-server = get_server(client_type = "vue2")
+server = get_server()
 
 # -----------------------------------------------------------------------------
 # GUI

--- a/01_vtk/app_cone.py
+++ b/01_vtk/app_cone.py
@@ -1,11 +1,11 @@
 from trame.app import get_server
-from trame.ui.vuetify import SinglePageLayout
+from trame.ui.vuetify3 import SinglePageLayout
 
 # -----------------------------------------------------------------------------
 # Get a server to work with
 # -----------------------------------------------------------------------------
 
-server = get_server(client_type = "vue2")
+server = get_server()
 
 # -----------------------------------------------------------------------------
 # GUI

--- a/01_vtk/app_flow.py
+++ b/01_vtk/app_flow.py
@@ -1,6 +1,6 @@
 from trame.app import get_server
 from trame.ui.vuetify3 import SinglePageLayout
-from trame.widgets import vtk, vuetify3
+from trame.widgets import vtk, vuetify3 as vuetify
 
 from vtkmodules.vtkFiltersSources import vtkConeSource
 from vtkmodules.vtkRenderingCore import (
@@ -51,7 +51,7 @@ with SinglePageLayout(server) as layout:
     layout.title.set_text("Hello trame")
 
     with layout.content:
-        with vuetify3.VContainer(
+        with vuetify.VContainer(
             fluid=True,
             classes="pa-0 fill-height",
         ):

--- a/01_vtk/app_flow.py
+++ b/01_vtk/app_flow.py
@@ -1,6 +1,6 @@
 from trame.app import get_server
-from trame.ui.vuetify import SinglePageLayout
-from trame.widgets import vtk, vuetify
+from trame.ui.vuetify3 import SinglePageLayout
+from trame.widgets import vtk, vuetify3
 
 from vtkmodules.vtkFiltersSources import vtkConeSource
 from vtkmodules.vtkRenderingCore import (
@@ -44,14 +44,14 @@ renderer.ResetCamera()
 # Trame
 # -----------------------------------------------------------------------------
 
-server = get_server(client_type = "vue2")
+server = get_server()
 ctrl = server.controller
 
 with SinglePageLayout(server) as layout:
     layout.title.set_text("Hello trame")
 
     with layout.content:
-        with vuetify.VContainer(
+        with vuetify3.VContainer(
             fluid=True,
             classes="pa-0 fill-height",
         ):

--- a/01_vtk/app_flow.py
+++ b/01_vtk/app_flow.py
@@ -1,6 +1,6 @@
 from trame.app import get_server
 from trame.ui.vuetify3 import SinglePageLayout
-from trame.widgets import vtk, vuetify3 as vuetify
+from trame.widgets import vtk, vuetify3
 
 from vtkmodules.vtkFiltersSources import vtkConeSource
 from vtkmodules.vtkRenderingCore import (
@@ -51,7 +51,7 @@ with SinglePageLayout(server) as layout:
     layout.title.set_text("Hello trame")
 
     with layout.content:
-        with vuetify.VContainer(
+        with vuetify3.VContainer(
             fluid=True,
             classes="pa-0 fill-height",
         ):

--- a/01_vtk/solution_cone.py
+++ b/01_vtk/solution_cone.py
@@ -1,6 +1,6 @@
 from trame.app import get_server
 from trame.ui.vuetify3 import SinglePageLayout
-from trame.widgets import vtk, vuetify3
+from trame.widgets import vtk, vuetify3 as vuetify
 
 from vtkmodules.vtkFiltersSources import vtkConeSource
 from vtkmodules.vtkRenderingCore import (
@@ -51,7 +51,7 @@ with SinglePageLayout(server) as layout:
     layout.title.set_text("Hello trame")
 
     with layout.content:
-        with vuetify3.VContainer(
+        with vuetify.VContainer(
             fluid=True,
             classes="pa-0 fill-height",
         ):

--- a/01_vtk/solution_cone.py
+++ b/01_vtk/solution_cone.py
@@ -55,7 +55,8 @@ with SinglePageLayout(server) as layout:
             fluid=True,
             classes="pa-0 fill-height",
         ):
-            view = vtk.VtkLocalView(renderWindow)
+            html_view = vtk.VtkLocalView(renderWindow)
+            ctrl.on_server_ready.add(html_view.update)
 
 
 # -----------------------------------------------------------------------------

--- a/01_vtk/solution_cone.py
+++ b/01_vtk/solution_cone.py
@@ -1,6 +1,6 @@
 from trame.app import get_server
-from trame.ui.vuetify import SinglePageLayout
-from trame.widgets import vtk, vuetify
+from trame.ui.vuetify3 import SinglePageLayout
+from trame.widgets import vtk, vuetify3
 
 from vtkmodules.vtkFiltersSources import vtkConeSource
 from vtkmodules.vtkRenderingCore import (
@@ -44,14 +44,14 @@ renderer.ResetCamera()
 # Trame
 # -----------------------------------------------------------------------------
 
-server = get_server(client_type = "vue2")
+server = get_server()
 ctrl = server.controller
 
 with SinglePageLayout(server) as layout:
     layout.title.set_text("Hello trame")
 
     with layout.content:
-        with vuetify.VContainer(
+        with vuetify3.VContainer(
             fluid=True,
             classes="pa-0 fill-height",
         ):

--- a/01_vtk/solution_cone.py
+++ b/01_vtk/solution_cone.py
@@ -1,6 +1,6 @@
 from trame.app import get_server
 from trame.ui.vuetify3 import SinglePageLayout
-from trame.widgets import vtk, vuetify3 as vuetify
+from trame.widgets import vtk, vuetify3
 
 from vtkmodules.vtkFiltersSources import vtkConeSource
 from vtkmodules.vtkRenderingCore import (
@@ -51,7 +51,7 @@ with SinglePageLayout(server) as layout:
     layout.title.set_text("Hello trame")
 
     with layout.content:
-        with vuetify.VContainer(
+        with vuetify3.VContainer(
             fluid=True,
             classes="pa-0 fill-height",
         ):

--- a/01_vtk/solution_flow.py
+++ b/01_vtk/solution_flow.py
@@ -1,7 +1,7 @@
 import os
 from trame.app import get_server
 from trame.ui.vuetify3 import SinglePageLayout
-from trame.widgets import vtk, vuetify3
+from trame.widgets import vtk, vuetify3 as vuetify
 
 from vtkmodules.vtkCommonColor import vtkNamedColors
 from vtkmodules.vtkCommonCore import vtkLookupTable
@@ -134,7 +134,7 @@ with SinglePageLayout(server) as layout:
     layout.title.set_text("Hello trame")
 
     with layout.content:
-        with vuetify3.VContainer(
+        with vuetify.VContainer(
             fluid=True,
             classes="pa-0 fill-height",
         ):

--- a/01_vtk/solution_flow.py
+++ b/01_vtk/solution_flow.py
@@ -1,7 +1,7 @@
 import os
 from trame.app import get_server
-from trame.ui.vuetify import SinglePageLayout
-from trame.widgets import vtk, vuetify
+from trame.ui.vuetify3 import SinglePageLayout
+from trame.widgets import vtk, vuetify3
 
 from vtkmodules.vtkCommonColor import vtkNamedColors
 from vtkmodules.vtkCommonCore import vtkLookupTable
@@ -127,14 +127,14 @@ renderWindow.Render()
 # GUI
 # -----------------------------------------------------------------------------
 
-server = get_server(client_type = "vue2")
+server = get_server()
 ctrl = server.controller
 
 with SinglePageLayout(server) as layout:
     layout.title.set_text("Hello trame")
 
     with layout.content:
-        with vuetify.VContainer(
+        with vuetify3.VContainer(
             fluid=True,
             classes="pa-0 fill-height",
         ):

--- a/01_vtk/solution_flow.py
+++ b/01_vtk/solution_flow.py
@@ -1,7 +1,7 @@
 import os
 from trame.app import get_server
 from trame.ui.vuetify3 import SinglePageLayout
-from trame.widgets import vtk, vuetify3 as vuetify
+from trame.widgets import vtk, vuetify3
 
 from vtkmodules.vtkCommonColor import vtkNamedColors
 from vtkmodules.vtkCommonCore import vtkLookupTable
@@ -134,7 +134,7 @@ with SinglePageLayout(server) as layout:
     layout.title.set_text("Hello trame")
 
     with layout.content:
-        with vuetify.VContainer(
+        with vuetify3.VContainer(
             fluid=True,
             classes="pa-0 fill-height",
         ):

--- a/01_vtk/solution_ray_cast.py
+++ b/01_vtk/solution_ray_cast.py
@@ -4,7 +4,7 @@
 import os
 from trame.app import get_server
 from trame.ui.vuetify3 import SinglePageLayout
-from trame.widgets import vtk, vuetify3
+from trame.widgets import vtk, vuetify3 as vuetify
 
 # -----------------------------------------------------------------------------
 # Example:    SimpleRayCast
@@ -104,7 +104,7 @@ with SinglePageLayout(server) as layout:
     layout.title.set_text("Hello trame")
 
     with layout.content:
-        with vuetify3.VContainer(
+        with vuetify.VContainer(
             fluid=True,
             classes="pa-0 fill-height",
         ):

--- a/01_vtk/solution_ray_cast.py
+++ b/01_vtk/solution_ray_cast.py
@@ -4,7 +4,7 @@
 import os
 from trame.app import get_server
 from trame.ui.vuetify3 import SinglePageLayout
-from trame.widgets import vtk, vuetify3 as vuetify
+from trame.widgets import vtk, vuetify3
 
 # -----------------------------------------------------------------------------
 # Example:    SimpleRayCast
@@ -104,7 +104,7 @@ with SinglePageLayout(server) as layout:
     layout.title.set_text("Hello trame")
 
     with layout.content:
-        with vuetify.VContainer(
+        with vuetify3.VContainer(
             fluid=True,
             classes="pa-0 fill-height",
         ):

--- a/01_vtk/solution_ray_cast.py
+++ b/01_vtk/solution_ray_cast.py
@@ -3,8 +3,8 @@
 # Web imports
 import os
 from trame.app import get_server
-from trame.ui.vuetify import SinglePageLayout
-from trame.widgets import vtk, vuetify
+from trame.ui.vuetify3 import SinglePageLayout
+from trame.widgets import vtk, vuetify3
 
 # -----------------------------------------------------------------------------
 # Example:    SimpleRayCast
@@ -97,14 +97,14 @@ ren1.ResetCamera()
 # Web Application setup
 # -----------------------------------------------------------------------------
 
-server = get_server(client_type = "vue2")
+server = get_server()
 ctrl = server.controller
 
 with SinglePageLayout(server) as layout:
     layout.title.set_text("Hello trame")
 
     with layout.content:
-        with vuetify.VContainer(
+        with vuetify3.VContainer(
             fluid=True,
             classes="pa-0 fill-height",
         ):

--- a/02_layouts/app_cone.py
+++ b/02_layouts/app_cone.py
@@ -1,6 +1,6 @@
 from trame.app import get_server
 from trame.ui.vuetify3 import SinglePageLayout
-from trame.widgets import vtk, vuetify3
+from trame.widgets import vtk, vuetify3 as vuetify
 
 from vtkmodules.vtkFiltersSources import vtkConeSource
 from vtkmodules.vtkRenderingCore import (
@@ -51,7 +51,7 @@ with SinglePageLayout(server) as layout:
     layout.title.set_text("Hello trame")
 
     with layout.content:
-        with vuetify3.VContainer(
+        with vuetify.VContainer(
             fluid=True,
             classes="pa-0 fill-height",
         ):

--- a/02_layouts/app_cone.py
+++ b/02_layouts/app_cone.py
@@ -1,6 +1,6 @@
 from trame.app import get_server
-from trame.ui.vuetify import SinglePageLayout
-from trame.widgets import vtk, vuetify
+from trame.ui.vuetify3 import SinglePageLayout
+from trame.widgets import vtk, vuetify3
 
 from vtkmodules.vtkFiltersSources import vtkConeSource
 from vtkmodules.vtkRenderingCore import (
@@ -44,14 +44,14 @@ renderer.ResetCamera()
 # Trame
 # -----------------------------------------------------------------------------
 
-server = get_server(client_type = "vue2")
+server = get_server()
 ctrl = server.controller
 
 with SinglePageLayout(server) as layout:
     layout.title.set_text("Hello trame")
 
     with layout.content:
-        with vuetify.VContainer(
+        with vuetify3.VContainer(
             fluid=True,
             classes="pa-0 fill-height",
         ):

--- a/02_layouts/app_cone.py
+++ b/02_layouts/app_cone.py
@@ -1,6 +1,6 @@
 from trame.app import get_server
 from trame.ui.vuetify3 import SinglePageLayout
-from trame.widgets import vtk, vuetify3 as vuetify
+from trame.widgets import vtk, vuetify3
 
 from vtkmodules.vtkFiltersSources import vtkConeSource
 from vtkmodules.vtkRenderingCore import (
@@ -51,7 +51,7 @@ with SinglePageLayout(server) as layout:
     layout.title.set_text("Hello trame")
 
     with layout.content:
-        with vuetify.VContainer(
+        with vuetify3.VContainer(
             fluid=True,
             classes="pa-0 fill-height",
         ):

--- a/02_layouts/solution_FullScreenPage.py
+++ b/02_layouts/solution_FullScreenPage.py
@@ -1,6 +1,6 @@
 from trame.app import get_server
 from trame.ui.vuetify3 import VAppLayout
-from trame.widgets import vtk, vuetify3
+from trame.widgets import vtk, vuetify3 as vuetify
 
 from vtkmodules.vtkFiltersSources import vtkConeSource
 from vtkmodules.vtkRenderingCore import (
@@ -49,7 +49,7 @@ ctrl = server.controller
 
 with VAppLayout(server) as layout:
     with layout.root:
-        with vuetify3.VContainer(
+        with vuetify.VContainer(
             fluid=True,
             classes="pa-0 fill-height",
         ):

--- a/02_layouts/solution_FullScreenPage.py
+++ b/02_layouts/solution_FullScreenPage.py
@@ -1,6 +1,6 @@
 from trame.app import get_server
 from trame.ui.vuetify3 import VAppLayout
-from trame.widgets import vtk, vuetify3 as vuetify
+from trame.widgets import vtk, vuetify3
 
 from vtkmodules.vtkFiltersSources import vtkConeSource
 from vtkmodules.vtkRenderingCore import (
@@ -49,7 +49,7 @@ ctrl = server.controller
 
 with VAppLayout(server) as layout:
     with layout.root:
-        with vuetify.VContainer(
+        with vuetify3.VContainer(
             fluid=True,
             classes="pa-0 fill-height",
         ):

--- a/02_layouts/solution_FullScreenPage.py
+++ b/02_layouts/solution_FullScreenPage.py
@@ -1,6 +1,6 @@
 from trame.app import get_server
-from trame.ui.vuetify import VAppLayout
-from trame.widgets import vtk, vuetify
+from trame.ui.vuetify3 import VAppLayout
+from trame.widgets import vtk, vuetify3
 
 from vtkmodules.vtkFiltersSources import vtkConeSource
 from vtkmodules.vtkRenderingCore import (
@@ -44,12 +44,12 @@ renderer.ResetCamera()
 # Trame
 # -----------------------------------------------------------------------------
 
-server = get_server(client_type = "vue2")
+server = get_server()
 ctrl = server.controller
 
 with VAppLayout(server) as layout:
     with layout.root:
-        with vuetify.VContainer(
+        with vuetify3.VContainer(
             fluid=True,
             classes="pa-0 fill-height",
         ):

--- a/02_layouts/solution_SinglePage.py
+++ b/02_layouts/solution_SinglePage.py
@@ -1,6 +1,6 @@
 from trame.app import get_server
 from trame.ui.vuetify3 import SinglePageLayout
-from trame.widgets import vtk, vuetify3
+from trame.widgets import vtk, vuetify3 as vuetify
 
 from vtkmodules.vtkFiltersSources import vtkConeSource
 from vtkmodules.vtkRenderingCore import (
@@ -51,7 +51,7 @@ with SinglePageLayout(server) as layout:
     layout.title.set_text("Hello trame")
 
     with layout.content:
-        with vuetify3.VContainer(
+        with vuetify.VContainer(
             fluid=True,
             classes="pa-0 fill-height",
         ):

--- a/02_layouts/solution_SinglePage.py
+++ b/02_layouts/solution_SinglePage.py
@@ -1,6 +1,6 @@
 from trame.app import get_server
-from trame.ui.vuetify import SinglePageLayout
-from trame.widgets import vtk, vuetify
+from trame.ui.vuetify3 import SinglePageLayout
+from trame.widgets import vtk, vuetify3
 
 from vtkmodules.vtkFiltersSources import vtkConeSource
 from vtkmodules.vtkRenderingCore import (
@@ -44,14 +44,14 @@ renderer.ResetCamera()
 # Trame
 # -----------------------------------------------------------------------------
 
-server = get_server(client_type = "vue2")
+server = get_server()
 ctrl = server.controller
 
 with SinglePageLayout(server) as layout:
     layout.title.set_text("Hello trame")
 
     with layout.content:
-        with vuetify.VContainer(
+        with vuetify3.VContainer(
             fluid=True,
             classes="pa-0 fill-height",
         ):

--- a/02_layouts/solution_SinglePage.py
+++ b/02_layouts/solution_SinglePage.py
@@ -1,6 +1,6 @@
 from trame.app import get_server
 from trame.ui.vuetify3 import SinglePageLayout
-from trame.widgets import vtk, vuetify3 as vuetify
+from trame.widgets import vtk, vuetify3
 
 from vtkmodules.vtkFiltersSources import vtkConeSource
 from vtkmodules.vtkRenderingCore import (
@@ -51,7 +51,7 @@ with SinglePageLayout(server) as layout:
     layout.title.set_text("Hello trame")
 
     with layout.content:
-        with vuetify.VContainer(
+        with vuetify3.VContainer(
             fluid=True,
             classes="pa-0 fill-height",
         ):

--- a/02_layouts/solution_SinglePageWithDrawer.py
+++ b/02_layouts/solution_SinglePageWithDrawer.py
@@ -1,6 +1,6 @@
 from trame.app import get_server
-from trame.ui.vuetify import SinglePageWithDrawerLayout
-from trame.widgets import vtk, vuetify
+from trame.ui.vuetify3 import SinglePageWithDrawerLayout
+from trame.widgets import vtk, vuetify3
 
 from vtkmodules.vtkFiltersSources import vtkConeSource
 from vtkmodules.vtkRenderingCore import (
@@ -44,14 +44,14 @@ renderer.ResetCamera()
 # Trame
 # -----------------------------------------------------------------------------
 
-server = get_server(client_type = "vue2")
+server = get_server()
 ctrl = server.controller
 
 with SinglePageWithDrawerLayout(server) as layout:
     layout.title.set_text("Hello trame")
 
     with layout.content:
-        with vuetify.VContainer(
+        with vuetify3.VContainer(
             fluid=True,
             classes="pa-0 fill-height",
         ):

--- a/02_layouts/solution_SinglePageWithDrawer.py
+++ b/02_layouts/solution_SinglePageWithDrawer.py
@@ -1,6 +1,6 @@
 from trame.app import get_server
 from trame.ui.vuetify3 import SinglePageWithDrawerLayout
-from trame.widgets import vtk, vuetify3 as vuetify
+from trame.widgets import vtk, vuetify3
 
 from vtkmodules.vtkFiltersSources import vtkConeSource
 from vtkmodules.vtkRenderingCore import (
@@ -51,7 +51,7 @@ with SinglePageWithDrawerLayout(server) as layout:
     layout.title.set_text("Hello trame")
 
     with layout.content:
-        with vuetify.VContainer(
+        with vuetify3.VContainer(
             fluid=True,
             classes="pa-0 fill-height",
         ):

--- a/02_layouts/solution_SinglePageWithDrawer.py
+++ b/02_layouts/solution_SinglePageWithDrawer.py
@@ -1,6 +1,6 @@
 from trame.app import get_server
 from trame.ui.vuetify3 import SinglePageWithDrawerLayout
-from trame.widgets import vtk, vuetify3
+from trame.widgets import vtk, vuetify3 as vuetify
 
 from vtkmodules.vtkFiltersSources import vtkConeSource
 from vtkmodules.vtkRenderingCore import (
@@ -51,7 +51,7 @@ with SinglePageWithDrawerLayout(server) as layout:
     layout.title.set_text("Hello trame")
 
     with layout.content:
-        with vuetify3.VContainer(
+        with vuetify.VContainer(
             fluid=True,
             classes="pa-0 fill-height",
         ):

--- a/03_html/app_cone.py
+++ b/03_html/app_cone.py
@@ -1,6 +1,6 @@
 from trame.app import get_server
 from trame.ui.vuetify3 import SinglePageLayout
-from trame.widgets import vtk, vuetify3
+from trame.widgets import vtk, vuetify3 as vuetify
 
 from vtkmodules.vtkFiltersSources import vtkConeSource
 from vtkmodules.vtkRenderingCore import (
@@ -51,7 +51,7 @@ with SinglePageLayout(server) as layout:
     layout.title.set_text("Hello trame")
 
     with layout.content:
-        with vuetify3.VContainer(
+        with vuetify.VContainer(
             fluid=True,
             classes="pa-0 fill-height",
         ):

--- a/03_html/app_cone.py
+++ b/03_html/app_cone.py
@@ -1,6 +1,6 @@
 from trame.app import get_server
-from trame.ui.vuetify import SinglePageLayout
-from trame.widgets import vtk, vuetify
+from trame.ui.vuetify3 import SinglePageLayout
+from trame.widgets import vtk, vuetify3
 
 from vtkmodules.vtkFiltersSources import vtkConeSource
 from vtkmodules.vtkRenderingCore import (
@@ -44,14 +44,14 @@ renderer.ResetCamera()
 # Trame
 # -----------------------------------------------------------------------------
 
-server = get_server(client_type = "vue2")
+server = get_server()
 ctrl = server.controller
 
 with SinglePageLayout(server) as layout:
     layout.title.set_text("Hello trame")
 
     with layout.content:
-        with vuetify.VContainer(
+        with vuetify3.VContainer(
             fluid=True,
             classes="pa-0 fill-height",
         ):

--- a/03_html/app_cone.py
+++ b/03_html/app_cone.py
@@ -1,6 +1,6 @@
-from trame.app import get_server
+from trame.app import TrameApp
 from trame.ui.vuetify3 import SinglePageLayout
-from trame.widgets import vtk, vuetify3
+from trame.widgets import vtk, vuetify3 as v3
 
 from vtkmodules.vtkFiltersSources import vtkConeSource
 from vtkmodules.vtkRenderingCore import (
@@ -12,55 +12,54 @@ from vtkmodules.vtkRenderingCore import (
 )
 
 # Required for interactor initialization
-from vtkmodules.vtkInteractionStyle import vtkInteractorStyleSwitch  # noqa
+from vtkmodules.vtkInteractionStyle import vtkInteractorStyleSwitch  # noqa: F401
 
 # Required for rendering initialization, not necessary for
 # local rendering, but doesn't hurt to include it
-import vtkmodules.vtkRenderingOpenGL2  # noqa
+import vtkmodules.vtkRenderingOpenGL2  # noqa: F401
 
+class AppCone(TrameApp):
+    def __init__(self, server=None):
+        super().__init__(server)
+        self.vtk_pipeline()
+        self._build_ui()
+    
+    def vtk_pipeline(self):
+        self.renderer = vtkRenderer()
+        self.renderWindow = vtkRenderWindow()
+        self.renderWindow.AddRenderer(self.renderer)
 
-# -----------------------------------------------------------------------------
-# VTK pipeline
-# -----------------------------------------------------------------------------
+        self.renderWindowInteractor = vtkRenderWindowInteractor()
+        self.renderWindowInteractor.SetRenderWindow(self.renderWindow)
+        self.renderWindowInteractor.GetInteractorStyle().SetCurrentStyleToTrackballCamera()
 
-renderer = vtkRenderer()
-renderWindow = vtkRenderWindow()
-renderWindow.AddRenderer(renderer)
+        self.cone_source = vtkConeSource()
+        self.mapper = vtkPolyDataMapper()
+        self.mapper.SetInputConnection(self.cone_source.GetOutputPort())
+        self.actor = vtkActor()
+        self.actor.SetMapper(self.mapper)
 
-renderWindowInteractor = vtkRenderWindowInteractor()
-renderWindowInteractor.SetRenderWindow(renderWindow)
-renderWindowInteractor.GetInteractorStyle().SetCurrentStyleToTrackballCamera()
+        self.renderer.AddActor(self.actor)
+        self.renderer.ResetCamera()
 
-cone_source = vtkConeSource()
-mapper = vtkPolyDataMapper()
-mapper.SetInputConnection(cone_source.GetOutputPort())
-actor = vtkActor()
-actor.SetMapper(mapper)
+    def _build_ui(self):
+        with SinglePageLayout(self.server) as self.ui:
+            self.ui.title.set_text("Hello trame")
 
-renderer.AddActor(actor)
-renderer.ResetCamera()
-
-# -----------------------------------------------------------------------------
-# Trame
-# -----------------------------------------------------------------------------
-
-server = get_server()
-ctrl = server.controller
-
-with SinglePageLayout(server) as layout:
-    layout.title.set_text("Hello trame")
-
-    with layout.content:
-        with vuetify3.VContainer(
-            fluid=True,
-            classes="pa-0 fill-height",
-        ):
-            view = vtk.VtkLocalView(renderWindow)
-
+            with self.ui.content:
+                with v3.VContainer(
+                    fluid=True,
+                    classes="pa-0 fill-height",
+                ):
+                    self.view = vtk.VtkLocalView(self.renderWindow)
 
 # -----------------------------------------------------------------------------
 # Main
 # -----------------------------------------------------------------------------
 
+def main():
+    app = AppCone()
+    app.server.start()
+
 if __name__ == "__main__":
-    server.start()
+    main()

--- a/03_html/app_cone.py
+++ b/03_html/app_cone.py
@@ -1,6 +1,6 @@
 from trame.app import get_server
 from trame.ui.vuetify3 import SinglePageLayout
-from trame.widgets import vtk, vuetify3 as vuetify
+from trame.widgets import vtk, vuetify3
 
 from vtkmodules.vtkFiltersSources import vtkConeSource
 from vtkmodules.vtkRenderingCore import (
@@ -51,7 +51,7 @@ with SinglePageLayout(server) as layout:
     layout.title.set_text("Hello trame")
 
     with layout.content:
-        with vuetify.VContainer(
+        with vuetify3.VContainer(
             fluid=True,
             classes="pa-0 fill-height",
         ):

--- a/03_html/solution_buttons.py
+++ b/03_html/solution_buttons.py
@@ -65,7 +65,7 @@ with SinglePageLayout(server, theme=("theme", "light")) as layout:
             false_value="light",
             true_value="dark",
             hide_details=True,
-            dense=True,
+            density="compact",
         )
         with vuetify3.VBtn(icon=True, click=ctrl.view_reset_camera):
             vuetify3.VIcon("mdi-crop-free")

--- a/03_html/solution_buttons.py
+++ b/03_html/solution_buttons.py
@@ -1,6 +1,6 @@
-from trame.app import get_server
+from trame.app import TrameApp
 from trame.ui.vuetify3 import SinglePageLayout
-from trame.widgets import vtk, vuetify3
+from trame.widgets import vtk, vuetify3 as v3
 
 from vtkmodules.vtkFiltersSources import vtkConeSource
 from vtkmodules.vtkRenderingCore import (
@@ -12,66 +12,67 @@ from vtkmodules.vtkRenderingCore import (
 )
 
 # Required for interactor initialization
-from vtkmodules.vtkInteractionStyle import vtkInteractorStyleSwitch  # noqa
+from vtkmodules.vtkInteractionStyle import vtkInteractorStyleSwitch  # noqa: F401
 
 # Required for rendering initialization, not necessary for
 # local rendering, but doesn't hurt to include it
-import vtkmodules.vtkRenderingOpenGL2  # noqa
+import vtkmodules.vtkRenderingOpenGL2  # noqa: F401
 
+class AppButtons(TrameApp):
+    def __init__(self, server=None):
+        super().__init__(server)
+        self.vtk_pipeline()
+        self._build_ui()
 
-# -----------------------------------------------------------------------------
-# VTK pipeline
-# -----------------------------------------------------------------------------
+    def vtk_pipeline(self):
+        self.renderer = vtkRenderer()
+        self.renderWindow = vtkRenderWindow()
+        self.renderWindow.AddRenderer(self.renderer)
 
-renderer = vtkRenderer()
-renderWindow = vtkRenderWindow()
-renderWindow.AddRenderer(renderer)
+        self.renderWindowInteractor = vtkRenderWindowInteractor()
+        self.renderWindowInteractor.SetRenderWindow(self.renderWindow)
+        self.renderWindowInteractor.GetInteractorStyle().SetCurrentStyleToTrackballCamera()
 
-renderWindowInteractor = vtkRenderWindowInteractor()
-renderWindowInteractor.SetRenderWindow(renderWindow)
-renderWindowInteractor.GetInteractorStyle().SetCurrentStyleToTrackballCamera()
+        self.cone_source = vtkConeSource()
+        self.mapper = vtkPolyDataMapper()
+        self.mapper.SetInputConnection(self.cone_source.GetOutputPort())
+        self.actor = vtkActor()
+        self.actor.SetMapper(self.mapper)
 
-cone_source = vtkConeSource()
-mapper = vtkPolyDataMapper()
-mapper.SetInputConnection(cone_source.GetOutputPort())
-actor = vtkActor()
-actor.SetMapper(mapper)
+        self.renderer.AddActor(self.actor)
+        self.renderer.ResetCamera()
 
-renderer.AddActor(actor)
-renderer.ResetCamera()
+    def _build_ui(self):
+        with SinglePageLayout(self.server, theme=("theme", "light")) as self.ui:
+            self.ui.title.set_text("Hello trame")
 
-# -----------------------------------------------------------------------------
-# Trame
-# -----------------------------------------------------------------------------
+            with self.ui.content:
+                with v3.VContainer(
+                    fluid=True,
+                    classes="pa-0 fill-height",
+                ):
+                    self.view = vtk.VtkLocalView(self.renderWindow)
+                    self.ctrl.view_reset_camera = self.view.reset_camera
+                    self.ctrl.view_update = self.view.update
 
-server = get_server()
-ctrl = server.controller
-
-with SinglePageLayout(server, theme=("theme", "light")) as layout:
-    layout.title.set_text("Hello trame")
-
-    with layout.content:
-        with vuetify3.VContainer(
-            fluid=True,
-            classes="pa-0 fill-height",
-        ):
-            view = vtk.VtkLocalView(renderWindow)
-            ctrl.view_reset_camera = view.reset_camera
-
-    with layout.toolbar:
-        vuetify3.VSpacer()
-        vuetify3.VSwitch(
-            v_model="theme",
-            false_value="light",
-            true_value="dark",
-            hide_details=True,
-            density="compact",
-        )
-        vuetify3.VBtn(icon="mdi-crop-free", click=ctrl.view_reset_camera)
+            with self.ui.toolbar:
+                v3.VSpacer()
+                v3.VSwitch(
+                    v_model="theme",
+                    false_value="light",
+                    true_value="dark",
+                    hide_details=True,
+                    density="compact",
+                )
+                v3.VBtn(icon="mdi-crop-free", click=self.ctrl.view_reset_camera)
 
 # -----------------------------------------------------------------------------
 # Main
 # -----------------------------------------------------------------------------
 
+def main():
+    app = AppButtons()
+    app.server.start()
+
 if __name__ == "__main__":
-    server.start()
+    main()

--- a/03_html/solution_buttons.py
+++ b/03_html/solution_buttons.py
@@ -1,6 +1,6 @@
 from trame.app import get_server
-from trame.ui.vuetify import SinglePageLayout
-from trame.widgets import vtk, vuetify
+from trame.ui.vuetify3 import SinglePageLayout
+from trame.widgets import vtk, vuetify3
 
 from vtkmodules.vtkFiltersSources import vtkConeSource
 from vtkmodules.vtkRenderingCore import (
@@ -44,14 +44,14 @@ renderer.ResetCamera()
 # Trame
 # -----------------------------------------------------------------------------
 
-server = get_server(client_type = "vue2")
+server = get_server()
 ctrl = server.controller
 
 with SinglePageLayout(server) as layout:
     layout.title.set_text("Hello trame")
 
     with layout.content:
-        with vuetify.VContainer(
+        with vuetify3.VContainer(
             fluid=True,
             classes="pa-0 fill-height",
         ):
@@ -59,14 +59,15 @@ with SinglePageLayout(server) as layout:
             ctrl.view_reset_camera = view.reset_camera
 
     with layout.toolbar:
-        vuetify.VSpacer()
-        vuetify.VSwitch(
+        vuetify3.VSpacer()
+        vuetify3.VSwitch(
             v_model="$vuetify.theme.dark",
+            click="theme.toggle()",
             hide_details=True,
             dense=True,
         )
-        with vuetify.VBtn(icon=True, click=ctrl.view_reset_camera):
-            vuetify.VIcon("mdi-crop-free")
+        with vuetify3.VBtn(icon=True, click=ctrl.view_reset_camera):
+            vuetify3.VIcon("mdi-crop-free")
 
 # -----------------------------------------------------------------------------
 # Main

--- a/03_html/solution_buttons.py
+++ b/03_html/solution_buttons.py
@@ -1,6 +1,6 @@
 from trame.app import get_server
 from trame.ui.vuetify3 import SinglePageLayout
-from trame.widgets import vtk, vuetify3 as vuetify
+from trame.widgets import vtk, vuetify3
 
 from vtkmodules.vtkFiltersSources import vtkConeSource
 from vtkmodules.vtkRenderingCore import (
@@ -51,7 +51,7 @@ with SinglePageLayout(server, theme=("theme", "light")) as layout:
     layout.title.set_text("Hello trame")
 
     with layout.content:
-        with vuetify.VContainer(
+        with vuetify3.VContainer(
             fluid=True,
             classes="pa-0 fill-height",
         ):
@@ -59,16 +59,16 @@ with SinglePageLayout(server, theme=("theme", "light")) as layout:
             ctrl.view_reset_camera = view.reset_camera
 
     with layout.toolbar:
-        vuetify.VSpacer()
-        vuetify.VSwitch(
+        vuetify3.VSpacer()
+        vuetify3.VSwitch(
             v_model="theme",
             false_value="light",
             true_value="dark",
             hide_details=True,
             dense=True,
         )
-        with vuetify.VBtn(icon=True, click=ctrl.view_reset_camera):
-            vuetify.VIcon("mdi-crop-free")
+        with vuetify3.VBtn(icon=True, click=ctrl.view_reset_camera):
+            vuetify3.VIcon("mdi-crop-free")
 
 # -----------------------------------------------------------------------------
 # Main

--- a/03_html/solution_buttons.py
+++ b/03_html/solution_buttons.py
@@ -67,8 +67,7 @@ with SinglePageLayout(server, theme=("theme", "light")) as layout:
             hide_details=True,
             density="compact",
         )
-        with vuetify3.VBtn(icon=True, click=ctrl.view_reset_camera):
-            vuetify3.VIcon("mdi-crop-free")
+        vuetify3.VBtn(icon="mdi-crop-free", click=ctrl.view_reset_camera)
 
 # -----------------------------------------------------------------------------
 # Main

--- a/03_html/solution_buttons.py
+++ b/03_html/solution_buttons.py
@@ -47,7 +47,7 @@ renderer.ResetCamera()
 server = get_server()
 ctrl = server.controller
 
-with SinglePageLayout(server) as layout:
+with SinglePageLayout(server, theme=("theme", "light")) as layout:
     layout.title.set_text("Hello trame")
 
     with layout.content:
@@ -61,8 +61,9 @@ with SinglePageLayout(server) as layout:
     with layout.toolbar:
         vuetify3.VSpacer()
         vuetify3.VSwitch(
-            v_model="$vuetify.theme.dark",
-            click="theme.toggle()",
+            v_model="theme",
+            false_value="light",
+            true_value="dark",
             hide_details=True,
             dense=True,
         )

--- a/03_html/solution_buttons.py
+++ b/03_html/solution_buttons.py
@@ -1,6 +1,6 @@
 from trame.app import get_server
 from trame.ui.vuetify3 import SinglePageLayout
-from trame.widgets import vtk, vuetify3
+from trame.widgets import vtk, vuetify3 as vuetify
 
 from vtkmodules.vtkFiltersSources import vtkConeSource
 from vtkmodules.vtkRenderingCore import (
@@ -51,7 +51,7 @@ with SinglePageLayout(server, theme=("theme", "light")) as layout:
     layout.title.set_text("Hello trame")
 
     with layout.content:
-        with vuetify3.VContainer(
+        with vuetify.VContainer(
             fluid=True,
             classes="pa-0 fill-height",
         ):
@@ -59,16 +59,16 @@ with SinglePageLayout(server, theme=("theme", "light")) as layout:
             ctrl.view_reset_camera = view.reset_camera
 
     with layout.toolbar:
-        vuetify3.VSpacer()
-        vuetify3.VSwitch(
+        vuetify.VSpacer()
+        vuetify.VSwitch(
             v_model="theme",
             false_value="light",
             true_value="dark",
             hide_details=True,
             dense=True,
         )
-        with vuetify3.VBtn(icon=True, click=ctrl.view_reset_camera):
-            vuetify3.VIcon("mdi-crop-free")
+        with vuetify.VBtn(icon=True, click=ctrl.view_reset_camera):
+            vuetify.VIcon("mdi-crop-free")
 
 # -----------------------------------------------------------------------------
 # Main

--- a/03_html/solution_final.py
+++ b/03_html/solution_final.py
@@ -1,6 +1,6 @@
 from trame.app import get_server
 from trame.ui.vuetify3 import SinglePageLayout
-from trame.widgets import vtk, vuetify3 as vuetify
+from trame.widgets import vtk, vuetify3
 
 from vtkmodules.vtkFiltersSources import vtkConeSource
 from vtkmodules.vtkRenderingCore import (
@@ -75,7 +75,7 @@ with SinglePageLayout(server, theme=("theme", "light")) as layout:
     layout.title.set_text("Hello trame")
 
     with layout.content:
-        with vuetify.VContainer(
+        with vuetify3.VContainer(
             fluid=True,
             classes="pa-0 fill-height",
         ):
@@ -84,8 +84,8 @@ with SinglePageLayout(server, theme=("theme", "light")) as layout:
             ctrl.view_reset_camera = view.reset_camera
 
     with layout.toolbar:
-        vuetify.VSpacer()
-        vuetify.VSlider(
+        vuetify3.VSpacer()
+        vuetify3.VSlider(
             v_model=("resolution", DEFAULT_RESOLUTION),
             min=3,
             max=60,
@@ -94,20 +94,20 @@ with SinglePageLayout(server, theme=("theme", "light")) as layout:
             dense=True,
             style="max-width: 300px",
         )
-        with vuetify.VBtn(icon=True, click=reset_resolution):
-            vuetify.VIcon("mdi-restore")
+        with vuetify3.VBtn(icon=True, click=reset_resolution):
+            vuetify3.VIcon("mdi-restore")
 
-        vuetify.VDivider(vertical=True, classes="mx-2")
+        vuetify3.VDivider(vertical=True, classes="mx-2")
 
-        vuetify.VSwitch(
+        vuetify3.VSwitch(
             v_model="theme",
             false_value="light",
             true_value="dark",
             hide_details=True,
             dense=True,
         )
-        with vuetify.VBtn(icon=True, click=ctrl.view_reset_camera):
-            vuetify.VIcon("mdi-crop-free")
+        with vuetify3.VBtn(icon=True, click=ctrl.view_reset_camera):
+            vuetify3.VIcon("mdi-crop-free")
 
 # -----------------------------------------------------------------------------
 # Main

--- a/03_html/solution_final.py
+++ b/03_html/solution_final.py
@@ -1,6 +1,6 @@
 from trame.app import get_server
 from trame.ui.vuetify3 import SinglePageLayout
-from trame.widgets import vtk, vuetify3
+from trame.widgets import vtk, vuetify3 as vuetify
 
 from vtkmodules.vtkFiltersSources import vtkConeSource
 from vtkmodules.vtkRenderingCore import (
@@ -71,11 +71,11 @@ def reset_resolution():
 # GUI
 # -----------------------------------------------------------------------------
 
-with SinglePageLayout(server) as layout:
+with SinglePageLayout(server, theme=("theme", "light")) as layout:
     layout.title.set_text("Hello trame")
 
     with layout.content:
-        with vuetify3.VContainer(
+        with vuetify.VContainer(
             fluid=True,
             classes="pa-0 fill-height",
         ):
@@ -84,8 +84,8 @@ with SinglePageLayout(server) as layout:
             ctrl.view_reset_camera = view.reset_camera
 
     with layout.toolbar:
-        vuetify3.VSpacer()
-        vuetify3.VSlider(
+        vuetify.VSpacer()
+        vuetify.VSlider(
             v_model=("resolution", DEFAULT_RESOLUTION),
             min=3,
             max=60,
@@ -94,18 +94,20 @@ with SinglePageLayout(server) as layout:
             dense=True,
             style="max-width: 300px",
         )
-        with vuetify3.VBtn(icon=True, click=reset_resolution):
-            vuetify3.VIcon("mdi-restore")
+        with vuetify.VBtn(icon=True, click=reset_resolution):
+            vuetify.VIcon("mdi-restore")
 
-        vuetify3.VDivider(vertical=True, classes="mx-2")
+        vuetify.VDivider(vertical=True, classes="mx-2")
 
-        vuetify3.VSwitch(
-            v_model="$vuetify.theme.dark",
+        vuetify.VSwitch(
+            v_model="theme",
+            false_value="light",
+            true_value="dark",
             hide_details=True,
             dense=True,
         )
-        with vuetify3.VBtn(icon=True, click=ctrl.view_reset_camera):
-            vuetify3.VIcon("mdi-crop-free")
+        with vuetify.VBtn(icon=True, click=ctrl.view_reset_camera):
+            vuetify.VIcon("mdi-crop-free")
 
 # -----------------------------------------------------------------------------
 # Main

--- a/03_html/solution_final.py
+++ b/03_html/solution_final.py
@@ -1,6 +1,7 @@
-from trame.app import get_server
+from trame.app import TrameApp
 from trame.ui.vuetify3 import SinglePageLayout
-from trame.widgets import vtk, vuetify3
+from trame.widgets import vtk, vuetify3 as v3
+from trame.decorators import change
 
 from vtkmodules.vtkFiltersSources import vtkConeSource
 from vtkmodules.vtkRenderingCore import (
@@ -12,104 +13,85 @@ from vtkmodules.vtkRenderingCore import (
 )
 
 # Required for interactor initialization
-from vtkmodules.vtkInteractionStyle import vtkInteractorStyleSwitch  # noqa
+from vtkmodules.vtkInteractionStyle import vtkInteractorStyleSwitch  # noqa: F401
 
 # Required for rendering initialization, not necessary for
 # local rendering, but doesn't hurt to include it
-import vtkmodules.vtkRenderingOpenGL2  # noqa
-
-# -----------------------------------------------------------------------------
-# Globals
-# -----------------------------------------------------------------------------
+import vtkmodules.vtkRenderingOpenGL2  # noqa: F401
 
 DEFAULT_RESOLUTION = 6
 
-# -----------------------------------------------------------------------------
-# VTK pipeline
-# -----------------------------------------------------------------------------
+class AppButtons(TrameApp):
+    def __init__(self, server=None):
+        super().__init__(server)
+        self.vtk_pipeline()
+        self._build_ui()
 
-renderer = vtkRenderer()
-renderWindow = vtkRenderWindow()
-renderWindow.AddRenderer(renderer)
+    def vtk_pipeline(self):
+        self.renderer = vtkRenderer()
+        self.renderWindow = vtkRenderWindow()
+        self.renderWindow.AddRenderer(self.renderer)
 
-renderWindowInteractor = vtkRenderWindowInteractor()
-renderWindowInteractor.SetRenderWindow(renderWindow)
-renderWindowInteractor.GetInteractorStyle().SetCurrentStyleToTrackballCamera()
+        self.renderWindowInteractor = vtkRenderWindowInteractor()
+        self.renderWindowInteractor.SetRenderWindow(self.renderWindow)
+        self.renderWindowInteractor.GetInteractorStyle().SetCurrentStyleToTrackballCamera()
 
-cone_source = vtkConeSource()
-mapper = vtkPolyDataMapper()
-mapper.SetInputConnection(cone_source.GetOutputPort())
-actor = vtkActor()
-actor.SetMapper(mapper)
+        self.cone_source = vtkConeSource()
+        self.mapper = vtkPolyDataMapper()
+        self.mapper.SetInputConnection(self.cone_source.GetOutputPort())
+        self.actor = vtkActor()
+        self.actor.SetMapper(self.mapper)
 
-renderer.AddActor(actor)
-renderer.ResetCamera()
+        self.renderer.AddActor(self.actor)
+        self.renderer.ResetCamera()
+    
+    @change("resolution")
+    def update_resolution(self, resolution, **_kwargs):
+        self.cone_source.SetResolution(resolution)
+        self.ctrl.view_update()
 
-# -----------------------------------------------------------------------------
-# Trame setup
-# -----------------------------------------------------------------------------
+    def reset_resolution(self):
+        self.state.resolution = DEFAULT_RESOLUTION
 
-server = get_server()
-state, ctrl = server.state, server.controller
+    def _build_ui(self):
+        with SinglePageLayout(self.server, theme=("theme", "light")) as self.ui:
+            self.ui.title.set_text("Hello trame")
 
-# -----------------------------------------------------------------------------
-# Functions
-# -----------------------------------------------------------------------------
+            with self.ui.content:
+                with v3.VContainer(
+                    fluid=True,
+                    classes="pa-0 fill-height",
+                ):
+                    self.view = vtk.VtkLocalView(self.renderWindow)
+                    self.ctrl.view_reset_camera = self.view.reset_camera
+                    self.ctrl.view_update = self.view.update
 
-
-@state.change("resolution")
-def update_resolution(resolution, **kwargs):
-    cone_source.SetResolution(resolution)
-    ctrl.view_update()
-
-
-def reset_resolution():
-    state.resolution = DEFAULT_RESOLUTION
-
-
-# -----------------------------------------------------------------------------
-# GUI
-# -----------------------------------------------------------------------------
-
-with SinglePageLayout(server, theme=("theme", "light")) as layout:
-    layout.title.set_text("Hello trame")
-
-    with layout.content:
-        with vuetify3.VContainer(
-            fluid=True,
-            classes="pa-0 fill-height",
-        ):
-            view = vtk.VtkLocalView(renderWindow)
-            ctrl.view_update = view.update
-            ctrl.view_reset_camera = view.reset_camera
-
-    with layout.toolbar:
-        vuetify3.VSpacer()
-        vuetify3.VSlider(
-            v_model=("resolution", DEFAULT_RESOLUTION),
-            min=3,
-            max=60,
-            step=1,
-            hide_details=True,
-            density="compact",
-            style="max-width: 300px",
-        )
-        vuetify3.VBtn(icon="mdi-restore", click=reset_resolution)
-
-        vuetify3.VDivider(vertical=True, classes="mx-2")
-
-        vuetify3.VSwitch(
-            v_model="theme",
-            false_value="light",
-            true_value="dark",
-            hide_details=True,
-            density="compact",
-        )
-        vuetify3.VBtn(icon="mdi-crop-free", click=ctrl.view_reset_camera)
+            with self.ui.toolbar:
+                v3.VSpacer()
+                v3.VSlider(
+                    v_model=("resolution", DEFAULT_RESOLUTION), # (var_name, initial_value)
+                    min=3, max=60, step=1,                      # min/max/step
+                    hide_details=True, density="compact",       # presentation params
+                    style="max-width: 300px",                   # css style
+                )
+                v3.VBtn(icon="mdi-restore", click=self.reset_resolution)
+                v3.VDivider(vertical=True, classes="mx-2")
+                v3.VSwitch(
+                    v_model="theme",
+                    false_value="light",
+                    true_value="dark",
+                    hide_details=True,
+                    density="compact",
+                )
+                v3.VBtn(icon="mdi-crop-free", click=self.ctrl.view_reset_camera)
 
 # -----------------------------------------------------------------------------
 # Main
 # -----------------------------------------------------------------------------
 
+def main():
+    app = AppButtons()
+    app.server.start()
+
 if __name__ == "__main__":
-    server.start()
+    main()

--- a/03_html/solution_final.py
+++ b/03_html/solution_final.py
@@ -94,8 +94,7 @@ with SinglePageLayout(server, theme=("theme", "light")) as layout:
             density="compact",
             style="max-width: 300px",
         )
-        with vuetify3.VBtn(icon=True, click=reset_resolution):
-            vuetify3.VIcon("mdi-restore")
+        vuetify3.VBtn(icon="mdi-restore", click=reset_resolution)
 
         vuetify3.VDivider(vertical=True, classes="mx-2")
 
@@ -106,8 +105,7 @@ with SinglePageLayout(server, theme=("theme", "light")) as layout:
             hide_details=True,
             density="compact",
         )
-        with vuetify3.VBtn(icon=True, click=ctrl.view_reset_camera):
-            vuetify3.VIcon("mdi-crop-free")
+        vuetify3.VBtn(icon="mdi-crop-free", click=ctrl.view_reset_camera)
 
 # -----------------------------------------------------------------------------
 # Main

--- a/03_html/solution_final.py
+++ b/03_html/solution_final.py
@@ -91,7 +91,7 @@ with SinglePageLayout(server, theme=("theme", "light")) as layout:
             max=60,
             step=1,
             hide_details=True,
-            dense=True,
+            density="compact",
             style="max-width: 300px",
         )
         with vuetify3.VBtn(icon=True, click=reset_resolution):
@@ -104,7 +104,7 @@ with SinglePageLayout(server, theme=("theme", "light")) as layout:
             false_value="light",
             true_value="dark",
             hide_details=True,
-            dense=True,
+            density="compact",
         )
         with vuetify3.VBtn(icon=True, click=ctrl.view_reset_camera):
             vuetify3.VIcon("mdi-crop-free")

--- a/03_html/solution_final.py
+++ b/03_html/solution_final.py
@@ -1,6 +1,6 @@
 from trame.app import get_server
-from trame.ui.vuetify import SinglePageLayout
-from trame.widgets import vtk, vuetify
+from trame.ui.vuetify3 import SinglePageLayout
+from trame.widgets import vtk, vuetify3
 
 from vtkmodules.vtkFiltersSources import vtkConeSource
 from vtkmodules.vtkRenderingCore import (
@@ -49,7 +49,7 @@ renderer.ResetCamera()
 # Trame setup
 # -----------------------------------------------------------------------------
 
-server = get_server(client_type = "vue2")
+server = get_server()
 state, ctrl = server.state, server.controller
 
 # -----------------------------------------------------------------------------
@@ -75,7 +75,7 @@ with SinglePageLayout(server) as layout:
     layout.title.set_text("Hello trame")
 
     with layout.content:
-        with vuetify.VContainer(
+        with vuetify3.VContainer(
             fluid=True,
             classes="pa-0 fill-height",
         ):
@@ -84,8 +84,8 @@ with SinglePageLayout(server) as layout:
             ctrl.view_reset_camera = view.reset_camera
 
     with layout.toolbar:
-        vuetify.VSpacer()
-        vuetify.VSlider(
+        vuetify3.VSpacer()
+        vuetify3.VSlider(
             v_model=("resolution", DEFAULT_RESOLUTION),
             min=3,
             max=60,
@@ -94,18 +94,18 @@ with SinglePageLayout(server) as layout:
             dense=True,
             style="max-width: 300px",
         )
-        with vuetify.VBtn(icon=True, click=reset_resolution):
-            vuetify.VIcon("mdi-restore")
+        with vuetify3.VBtn(icon=True, click=reset_resolution):
+            vuetify3.VIcon("mdi-restore")
 
-        vuetify.VDivider(vertical=True, classes="mx-2")
+        vuetify3.VDivider(vertical=True, classes="mx-2")
 
-        vuetify.VSwitch(
+        vuetify3.VSwitch(
             v_model="$vuetify.theme.dark",
             hide_details=True,
             dense=True,
         )
-        with vuetify.VBtn(icon=True, click=ctrl.view_reset_camera):
-            vuetify.VIcon("mdi-crop-free")
+        with vuetify3.VBtn(icon=True, click=ctrl.view_reset_camera):
+            vuetify3.VIcon("mdi-crop-free")
 
 # -----------------------------------------------------------------------------
 # Main

--- a/04_application/app.py
+++ b/04_application/app.py
@@ -2,7 +2,7 @@ import os
 
 from trame.app import get_server
 from trame.ui.vuetify3 import SinglePageLayout
-from trame.widgets import vtk, vuetify3 as vuetify
+from trame.widgets import vtk, vuetify3
 
 from vtkmodules.vtkRenderingCore import (
     vtkActor,
@@ -86,7 +86,7 @@ with SinglePageLayout(server) as layout:
 
     with layout.content:
         # content components
-        with vuetify.VContainer(
+        with vuetify3.VContainer(
             fluid=True,
             classes="pa-0 fill-height",
         ):

--- a/04_application/app.py
+++ b/04_application/app.py
@@ -2,7 +2,7 @@ import os
 
 from trame.app import get_server
 from trame.ui.vuetify3 import SinglePageLayout
-from trame.widgets import vtk, vuetify3
+from trame.widgets import vtk, vuetify3 as vuetify
 
 from vtkmodules.vtkRenderingCore import (
     vtkActor,
@@ -86,7 +86,7 @@ with SinglePageLayout(server) as layout:
 
     with layout.content:
         # content components
-        with vuetify3.VContainer(
+        with vuetify.VContainer(
             fluid=True,
             classes="pa-0 fill-height",
         ):

--- a/04_application/app.py
+++ b/04_application/app.py
@@ -1,8 +1,8 @@
 import os
 
 from trame.app import get_server
-from trame.ui.vuetify import SinglePageLayout
-from trame.widgets import vtk, vuetify
+from trame.ui.vuetify3 import SinglePageLayout
+from trame.widgets import vtk, vuetify3
 
 from vtkmodules.vtkRenderingCore import (
     vtkActor,
@@ -62,7 +62,7 @@ renderer.ResetCamera()
 # Trame setup
 # -----------------------------------------------------------------------------
 
-server = get_server(client_type="vue2")
+server = get_server()
 state, ctrl = server.state, server.controller
 
 # -----------------------------------------------------------------------------
@@ -86,7 +86,7 @@ with SinglePageLayout(server) as layout:
 
     with layout.content:
         # content components
-        with vuetify.VContainer(
+        with vuetify3.VContainer(
             fluid=True,
             classes="pa-0 fill-height",
         ):

--- a/04_application/app.py
+++ b/04_application/app.py
@@ -1,8 +1,10 @@
 import os
 
-from trame.app import get_server
+from trame.app import TrameApp
 from trame.ui.vuetify3 import SinglePageLayout
-from trame.widgets import vtk, vuetify3
+from trame.widgets import vuetify3 as v3
+from trame.widgets import vtk, trame
+from trame.decorators import change
 
 from vtkmodules.vtkRenderingCore import (
     vtkActor,
@@ -62,8 +64,9 @@ renderer.ResetCamera()
 # Trame setup
 # -----------------------------------------------------------------------------
 
-server = get_server()
-state, ctrl = server.state, server.controller
+class App(TrameApp):
+    def __init__(self, server=None):
+        super().__init__(server)
 
 # -----------------------------------------------------------------------------
 # Callbacks
@@ -77,26 +80,31 @@ state, ctrl = server.state, server.controller
 # GUI
 # -----------------------------------------------------------------------------
 
-with SinglePageLayout(server) as layout:
-    layout.title.set_text("Viewer")
+    def _build_ui(self):
+        with SinglePageLayout(self.server) as self.ui:
+            self.ui.title.set_text("Viewer")
 
-    with layout.toolbar:
-        # toolbar components
-        pass
+            with self.ui.toolbar:
+                # toolbar components
+                pass
 
-    with layout.content:
-        # content components
-        with vuetify3.VContainer(
-            fluid=True,
-            classes="pa-0 fill-height",
-        ):
-            view = vtk.VtkLocalView(renderWindow)
-            ctrl.view_update = view.update
-            ctrl.view_reset_camera = view.reset_camera
+            with self.ui.content:
+                # content components
+                with v3.VContainer(
+                    fluid=True,
+                    classes="pa-0 fill-height",
+                ):
+                    view = vtk.VtkLocalView(renderWindow)
+                    self.ctrl.view_update = view.update
+                    self.ctrl.view_reset_camera = view.reset_camera
 
 # -----------------------------------------------------------------------------
 # Main
 # -----------------------------------------------------------------------------
 
+def main():
+    app = App()
+    app.server.start()
+
 if __name__ == "__main__":
-    server.start()
+    main()

--- a/04_application/solution.py
+++ b/04_application/solution.py
@@ -172,6 +172,69 @@ cube_axes.SetFlyModeToOuterEdges()
 
 renderer.ResetCamera()
 
+
+# -----------------------------------------------------------------------------
+# Callbacks for VTK actors
+# -----------------------------------------------------------------------------
+
+
+# Representation Callback
+def update_representation(actor, mode):
+    property = actor.GetProperty()
+    if mode == Representation.Points:
+        property.SetRepresentationToPoints()
+        property.SetPointSize(5)
+        property.EdgeVisibilityOff()
+    elif mode == Representation.Wireframe:
+        property.SetRepresentationToWireframe()
+        property.SetPointSize(1)
+        property.EdgeVisibilityOff()
+    elif mode == Representation.Surface:
+        property.SetRepresentationToSurface()
+        property.SetPointSize(1)
+        property.EdgeVisibilityOff()
+    elif mode == Representation.SurfaceWithEdges:
+        property.SetRepresentationToSurface()
+        property.SetPointSize(1)
+        property.EdgeVisibilityOn()
+
+
+# Color By Callback
+def color_by_array(actor, array):
+    _min, _max = array.get("range")
+    mapper = actor.GetMapper()
+    mapper.SelectColorArray(array.get("text"))
+    mapper.GetLookupTable().SetRange(_min, _max)
+    if array.get("type") == vtkDataObject.FIELD_ASSOCIATION_POINTS:
+        mesh_mapper.SetScalarModeToUsePointFieldData()
+    else:
+        mesh_mapper.SetScalarModeToUseCellFieldData()
+    mapper.SetScalarVisibility(True)
+    mapper.SetUseLookupTableScalarRange(True)
+
+
+# Color Map Callback
+def use_preset(actor, preset):
+    lut = actor.GetMapper().GetLookupTable()
+    if preset == LookupTable.Rainbow:
+        lut.SetHueRange(0.666, 0.0)
+        lut.SetSaturationRange(1.0, 1.0)
+        lut.SetValueRange(1.0, 1.0)
+    elif preset == LookupTable.Inverted_Rainbow:
+        lut.SetHueRange(0.0, 0.666)
+        lut.SetSaturationRange(1.0, 1.0)
+        lut.SetValueRange(1.0, 1.0)
+    elif preset == LookupTable.Greyscale:
+        lut.SetHueRange(0.0, 0.0)
+        lut.SetSaturationRange(0.0, 0.0)
+        lut.SetValueRange(0.0, 1.0)
+    elif preset == LookupTable.Inverted_Greyscale:
+        lut.SetHueRange(0.0, 0.666)
+        lut.SetSaturationRange(0.0, 0.0)
+        lut.SetValueRange(1.0, 0.0)
+    lut.Build()
+
+
 # -----------------------------------------------------------------------------
 # Trame setup
 # -----------------------------------------------------------------------------
@@ -187,7 +250,7 @@ class App(TrameApp):
 # -----------------------------------------------------------------------------
 
     @change("cube_axes_visibility")
-    def update_cube_axes_visibility(self, cube_axes_visibility, **kwargs):
+    def update_cube_axes_visibility(self, cube_axes_visibility, **_):
         cube_axes.SetVisibility(cube_axes_visibility)
         self.ctrl.view_update()
 
@@ -215,98 +278,41 @@ class App(TrameApp):
         self.ctrl.view_update()
 
 
-    # Representation Callbacks
-    def update_representation(self, actor, mode):
-        property = actor.GetProperty()
-        if mode == Representation.Points:
-            property.SetRepresentationToPoints()
-            property.SetPointSize(5)
-            property.EdgeVisibilityOff()
-        elif mode == Representation.Wireframe:
-            property.SetRepresentationToWireframe()
-            property.SetPointSize(1)
-            property.EdgeVisibilityOff()
-        elif mode == Representation.Surface:
-            property.SetRepresentationToSurface()
-            property.SetPointSize(1)
-            property.EdgeVisibilityOff()
-        elif mode == Representation.SurfaceWithEdges:
-            property.SetRepresentationToSurface()
-            property.SetPointSize(1)
-            property.EdgeVisibilityOn()
-
-
     @change("mesh_representation")
     def update_mesh_representation(self, mesh_representation, **kwargs):
-        self.update_representation(mesh_actor, mesh_representation)
+        update_representation(mesh_actor, mesh_representation)
         self.ctrl.view_update()
 
 
     @change("contour_representation")
     def update_contour_representation(self, contour_representation, **kwargs):
-        self.update_representation(contour_actor, contour_representation)
+        update_representation(contour_actor, contour_representation)
         self.ctrl.view_update()
-
-
-    # Color By Callbacks
-    def color_by_array(self, actor, array):
-        _min, _max = array.get("range")
-        mapper = actor.GetMapper()
-        mapper.SelectColorArray(array.get("text"))
-        mapper.GetLookupTable().SetRange(_min, _max)
-        if array.get("type") == vtkDataObject.FIELD_ASSOCIATION_POINTS:
-            mesh_mapper.SetScalarModeToUsePointFieldData()
-        else:
-            mesh_mapper.SetScalarModeToUseCellFieldData()
-        mapper.SetScalarVisibility(True)
-        mapper.SetUseLookupTableScalarRange(True)
 
 
     @change("mesh_color_array_idx")
     def update_mesh_color_by_name(self, mesh_color_array_idx, **kwargs):
         array = dataset_arrays[mesh_color_array_idx]
-        self.color_by_array(mesh_actor, array)
+        color_by_array(mesh_actor, array)
         self.ctrl.view_update()
 
 
     @change("contour_color_array_idx")
     def update_contour_color_by_name(self, contour_color_array_idx, **kwargs):
         array = dataset_arrays[contour_color_array_idx]
-        self.color_by_array(contour_actor, array)
+        color_by_array(contour_actor, array)
         self.ctrl.view_update()
-
-
-    # Color Map Callbacks
-    def use_preset(self, actor, preset):
-        lut = actor.GetMapper().GetLookupTable()
-        if preset == LookupTable.Rainbow:
-            lut.SetHueRange(0.666, 0.0)
-            lut.SetSaturationRange(1.0, 1.0)
-            lut.SetValueRange(1.0, 1.0)
-        elif preset == LookupTable.Inverted_Rainbow:
-            lut.SetHueRange(0.0, 0.666)
-            lut.SetSaturationRange(1.0, 1.0)
-            lut.SetValueRange(1.0, 1.0)
-        elif preset == LookupTable.Greyscale:
-            lut.SetHueRange(0.0, 0.0)
-            lut.SetSaturationRange(0.0, 0.0)
-            lut.SetValueRange(0.0, 1.0)
-        elif preset == LookupTable.Inverted_Greyscale:
-            lut.SetHueRange(0.0, 0.666)
-            lut.SetSaturationRange(0.0, 0.0)
-            lut.SetValueRange(1.0, 0.0)
-        lut.Build()
 
 
     @change("mesh_color_preset")
     def update_mesh_color_preset(self, mesh_color_preset, **kwargs):
-        self.use_preset(mesh_actor, mesh_color_preset)
+        use_preset(mesh_actor, mesh_color_preset)
         self.ctrl.view_update()
 
 
     @change("contour_color_preset")
     def update_contour_color_preset(self, contour_color_preset, **kwargs):
-        self.use_preset(contour_actor, contour_color_preset)
+        use_preset(contour_actor, contour_color_preset)
         self.ctrl.view_update()
 
 

--- a/04_application/solution.py
+++ b/04_application/solution.py
@@ -2,7 +2,7 @@ import os
 
 from trame.app import get_server
 from trame.ui.vuetify3 import SinglePageWithDrawerLayout
-from trame.widgets import vtk, vuetify3, trame
+from trame.widgets import vtk, vuetify3 as vuetify, trame
 
 from trame_vtk.modules.vtk.serializers import configure_serializer
 
@@ -353,7 +353,7 @@ def update_contour_value(contour_value, **kwargs):
 
 
 def standard_buttons():
-    vuetify3.VCheckbox(
+    vuetify.VCheckbox(
         v_model=("cube_axes_visibility", True),
         true_icon="mdi-cube-outline",
         false_icon="mdi-cube-off-outline",
@@ -361,15 +361,17 @@ def standard_buttons():
         hide_details=True,
         dense=True,
     )
-    vuetify3.VCheckbox(
-        v_model="$vuetify.theme.dark",
+    vuetify.VCheckbox(
+        v_model="theme",
+        true_value="dark",
+        false_value="light",
         true_icon="mdi-lightbulb-off-outline",
         false_icon="mdi-lightbulb-outline",
         classes="mx-1",
         hide_details=True,
         dense=True,
     )
-    vuetify3.VCheckbox(
+    vuetify.VCheckbox(
         v_model=("viewMode", "local"),
         true_icon="mdi-lan-disconnect",
         false_icon="mdi-lan-connect",
@@ -379,8 +381,8 @@ def standard_buttons():
         hide_details=True,
         dense=True,
     )
-    with vuetify3.VBtn(icon=True, click=ctrl.view_reset_camera):
-        vuetify3.VIcon("mdi-crop-free")
+    with vuetify.VBtn(icon=True, click=ctrl.view_reset_camera):
+        vuetify.VIcon("mdi-crop-free")
 
 
 def pipeline_widget():
@@ -398,21 +400,21 @@ def pipeline_widget():
 
 
 def ui_card(title, ui_name):
-    with vuetify3.VCard(v_show=f"active_ui == '{ui_name}'"):
-        vuetify3.VCardTitle(
+    with vuetify.VCard(v_show=f"active_ui == '{ui_name}'"):
+        vuetify.VCardTitle(
             title,
             classes="grey lighten-1 py-1 grey--text text--darken-3",
             style="user-select: none; cursor: pointer",
             hide_details=True,
             dense=True,
         )
-        content = vuetify3.VCardText(classes="py-2")
+        content = vuetify.VCardText(classes="py-2")
     return content
 
 
 def mesh_card():
     with ui_card(title="Mesh", ui_name="mesh"):
-        vuetify3.VSelect(
+        vuetify.VSelect(
             # Representation
             v_model=("mesh_representation", Representation.Surface),
             items=(
@@ -432,9 +434,9 @@ def mesh_card():
             outlined=True,
             classes="pt-1",
         )
-        with vuetify3.VRow(classes="pt-2", dense=True):
-            with vuetify3.VCol(cols="6"):
-                vuetify3.VSelect(
+        with vuetify.VRow(classes="pt-2", dense=True):
+            with vuetify.VCol(cols="6"):
+                vuetify.VSelect(
                     # Color By
                     label="Color by",
                     v_model=("mesh_color_array_idx", 0),
@@ -446,8 +448,8 @@ def mesh_card():
                     outlined=True,
                     classes="pt-1",
                 )
-            with vuetify3.VCol(cols="6"):
-                vuetify3.VSelect(
+            with vuetify.VCol(cols="6"):
+                vuetify.VSelect(
                     # Color Map
                     label="Colormap",
                     v_model=("mesh_color_preset", LookupTable.Rainbow),
@@ -467,7 +469,7 @@ def mesh_card():
                     outlined=True,
                     classes="pt-1",
                 )
-        vuetify3.VSlider(
+        vuetify.VSlider(
             # Opacity
             v_model=("mesh_opacity", 1.0),
             min=0,
@@ -482,7 +484,7 @@ def mesh_card():
 
 def contour_card():
     with ui_card(title="Contour", ui_name="contour"):
-        vuetify3.VSelect(
+        vuetify.VSelect(
             # Contour By
             label="Contour by",
             v_model=("contour_by_array_idx", 0),
@@ -494,7 +496,7 @@ def contour_card():
             outlined=True,
             classes="pt-1",
         )
-        vuetify3.VSlider(
+        vuetify.VSlider(
             # Contour Value
             v_model=("contour_value", contour_value),
             min=("contour_min", default_min),
@@ -505,7 +507,7 @@ def contour_card():
             hide_details=True,
             dense=True,
         )
-        vuetify3.VSelect(
+        vuetify.VSelect(
             # Representation
             v_model=("contour_representation", Representation.Surface),
             items=(
@@ -525,9 +527,9 @@ def contour_card():
             outlined=True,
             classes="pt-1",
         )
-        with vuetify3.VRow(classes="pt-2", dense=True):
-            with vuetify3.VCol(cols="6"):
-                vuetify3.VSelect(
+        with vuetify.VRow(classes="pt-2", dense=True):
+            with vuetify.VCol(cols="6"):
+                vuetify.VSelect(
                     # Color By
                     label="Color by",
                     v_model=("contour_color_array_idx", 0),
@@ -539,8 +541,8 @@ def contour_card():
                     outlined=True,
                     classes="pt-1",
                 )
-            with vuetify3.VCol(cols="6"):
-                vuetify3.VSelect(
+            with vuetify.VCol(cols="6"):
+                vuetify.VSelect(
                     # Color Map
                     label="Colormap",
                     v_model=("contour_color_preset", LookupTable.Rainbow),
@@ -560,7 +562,7 @@ def contour_card():
                     outlined=True,
                     classes="pt-1",
                 )
-        vuetify3.VSlider(
+        vuetify.VSlider(
             # Opacity
             v_model=("contour_opacity", 1.0),
             min=0,
@@ -577,26 +579,26 @@ def contour_card():
 # GUI
 # -----------------------------------------------------------------------------
 
-with SinglePageWithDrawerLayout(server) as layout:
+with SinglePageWithDrawerLayout(server, theme=("theme", "light")) as layout:
     layout.title.set_text("Viewer")
 
     with layout.toolbar:
         # toolbar components
-        vuetify3.VSpacer()
-        vuetify3.VDivider(vertical=True, classes="mx-2")
+        vuetify.VSpacer()
+        vuetify.VDivider(vertical=True, classes="mx-2")
         standard_buttons()
 
     with layout.drawer as drawer:
         # drawer components
         drawer.width = 325
         pipeline_widget()
-        vuetify3.VDivider(classes="mb-2")
+        vuetify.VDivider(classes="mb-2")
         mesh_card()
         contour_card()
 
     with layout.content:
         # content components
-        with vuetify3.VContainer(
+        with vuetify.VContainer(
             fluid=True,
             classes="pa-0 fill-height",
         ):

--- a/04_application/solution.py
+++ b/04_application/solution.py
@@ -389,8 +389,7 @@ class App(TrameApp):
             hide_details=True,
             density="compact",
         )
-        with v3.VBtn(icon=True, click=self.ctrl.view_reset_camera):
-            v3.VIcon("mdi-crop-free")
+        v3.VBtn(icon="mdi-crop-free", click=self.ctrl.view_reset_camera)
 
 
     def pipeline_widget(self):

--- a/04_application/solution.py
+++ b/04_application/solution.py
@@ -1,8 +1,8 @@
 import os
 
 from trame.app import get_server
-from trame.ui.vuetify import SinglePageWithDrawerLayout
-from trame.widgets import vtk, vuetify, trame
+from trame.ui.vuetify3 import SinglePageWithDrawerLayout
+from trame.widgets import vtk, vuetify3, trame
 
 from trame_vtk.modules.vtk.serializers import configure_serializer
 
@@ -174,7 +174,7 @@ renderer.ResetCamera()
 # Trame setup
 # -----------------------------------------------------------------------------
 
-server = get_server(client_type="vue2")
+server = get_server()
 state, ctrl = server.state, server.controller
 
 state.setdefault("active_ui", None)
@@ -353,34 +353,34 @@ def update_contour_value(contour_value, **kwargs):
 
 
 def standard_buttons():
-    vuetify.VCheckbox(
+    vuetify3.VCheckbox(
         v_model=("cube_axes_visibility", True),
-        on_icon="mdi-cube-outline",
-        off_icon="mdi-cube-off-outline",
+        true_icon="mdi-cube-outline",
+        false_icon="mdi-cube-off-outline",
         classes="mx-1",
         hide_details=True,
         dense=True,
     )
-    vuetify.VCheckbox(
+    vuetify3.VCheckbox(
         v_model="$vuetify.theme.dark",
-        on_icon="mdi-lightbulb-off-outline",
-        off_icon="mdi-lightbulb-outline",
+        true_icon="mdi-lightbulb-off-outline",
+        false_icon="mdi-lightbulb-outline",
         classes="mx-1",
         hide_details=True,
         dense=True,
     )
-    vuetify.VCheckbox(
+    vuetify3.VCheckbox(
         v_model=("viewMode", "local"),
-        on_icon="mdi-lan-disconnect",
-        off_icon="mdi-lan-connect",
+        true_icon="mdi-lan-disconnect",
+        false_icon="mdi-lan-connect",
         true_value="local",
         false_value="remote",
         classes="mx-1",
         hide_details=True,
         dense=True,
     )
-    with vuetify.VBtn(icon=True, click="$refs.view.resetCamera()"):
-        vuetify.VIcon("mdi-crop-free")
+    with vuetify3.VBtn(icon=True, click=ctrl.view_reset_camera):
+        vuetify3.VIcon("mdi-crop-free")
 
 
 def pipeline_widget():
@@ -398,21 +398,21 @@ def pipeline_widget():
 
 
 def ui_card(title, ui_name):
-    with vuetify.VCard(v_show=f"active_ui == '{ui_name}'"):
-        vuetify.VCardTitle(
+    with vuetify3.VCard(v_show=f"active_ui == '{ui_name}'"):
+        vuetify3.VCardTitle(
             title,
             classes="grey lighten-1 py-1 grey--text text--darken-3",
             style="user-select: none; cursor: pointer",
             hide_details=True,
             dense=True,
         )
-        content = vuetify.VCardText(classes="py-2")
+        content = vuetify3.VCardText(classes="py-2")
     return content
 
 
 def mesh_card():
     with ui_card(title="Mesh", ui_name="mesh"):
-        vuetify.VSelect(
+        vuetify3.VSelect(
             # Representation
             v_model=("mesh_representation", Representation.Surface),
             items=(
@@ -424,26 +424,30 @@ def mesh_card():
                     {"text": "SurfaceWithEdges", "value": 3},
                 ],
             ),
+            item_title="text",
+            item_value="value",
             label="Representation",
             hide_details=True,
             dense=True,
             outlined=True,
             classes="pt-1",
         )
-        with vuetify.VRow(classes="pt-2", dense=True):
-            with vuetify.VCol(cols="6"):
-                vuetify.VSelect(
+        with vuetify3.VRow(classes="pt-2", dense=True):
+            with vuetify3.VCol(cols="6"):
+                vuetify3.VSelect(
                     # Color By
                     label="Color by",
                     v_model=("mesh_color_array_idx", 0),
                     items=("array_list", dataset_arrays),
+                    item_title="text",
+                    item_value="value",
                     hide_details=True,
                     dense=True,
                     outlined=True,
                     classes="pt-1",
                 )
-            with vuetify.VCol(cols="6"):
-                vuetify.VSelect(
+            with vuetify3.VCol(cols="6"):
+                vuetify3.VSelect(
                     # Color Map
                     label="Colormap",
                     v_model=("mesh_color_preset", LookupTable.Rainbow),
@@ -456,12 +460,14 @@ def mesh_card():
                             {"text": "Inv Greyscale", "value": 3},
                         ],
                     ),
+                    item_title="text",
+                    item_value="value",
                     hide_details=True,
                     dense=True,
                     outlined=True,
                     classes="pt-1",
                 )
-        vuetify.VSlider(
+        vuetify3.VSlider(
             # Opacity
             v_model=("mesh_opacity", 1.0),
             min=0,
@@ -476,17 +482,19 @@ def mesh_card():
 
 def contour_card():
     with ui_card(title="Contour", ui_name="contour"):
-        vuetify.VSelect(
+        vuetify3.VSelect(
             # Contour By
             label="Contour by",
             v_model=("contour_by_array_idx", 0),
             items=("array_list", dataset_arrays),
+            item_title="text",
+            item_value="value",
             hide_details=True,
             dense=True,
             outlined=True,
             classes="pt-1",
         )
-        vuetify.VSlider(
+        vuetify3.VSlider(
             # Contour Value
             v_model=("contour_value", contour_value),
             min=("contour_min", default_min),
@@ -497,7 +505,7 @@ def contour_card():
             hide_details=True,
             dense=True,
         )
-        vuetify.VSelect(
+        vuetify3.VSelect(
             # Representation
             v_model=("contour_representation", Representation.Surface),
             items=(
@@ -509,26 +517,30 @@ def contour_card():
                     {"text": "SurfaceWithEdges", "value": 3},
                 ],
             ),
+            item_title="text",
+            item_value="value",
             label="Representation",
             hide_details=True,
             dense=True,
             outlined=True,
             classes="pt-1",
         )
-        with vuetify.VRow(classes="pt-2", dense=True):
-            with vuetify.VCol(cols="6"):
-                vuetify.VSelect(
+        with vuetify3.VRow(classes="pt-2", dense=True):
+            with vuetify3.VCol(cols="6"):
+                vuetify3.VSelect(
                     # Color By
                     label="Color by",
                     v_model=("contour_color_array_idx", 0),
                     items=("array_list", dataset_arrays),
+                    item_title="text",
+                    item_value="value",
                     hide_details=True,
                     dense=True,
                     outlined=True,
                     classes="pt-1",
                 )
-            with vuetify.VCol(cols="6"):
-                vuetify.VSelect(
+            with vuetify3.VCol(cols="6"):
+                vuetify3.VSelect(
                     # Color Map
                     label="Colormap",
                     v_model=("contour_color_preset", LookupTable.Rainbow),
@@ -541,12 +553,14 @@ def contour_card():
                             {"text": "Inv Greyscale", "value": 3},
                         ],
                     ),
+                    item_title="text",
+                    item_value="value",
                     hide_details=True,
                     dense=True,
                     outlined=True,
                     classes="pt-1",
                 )
-        vuetify.VSlider(
+        vuetify3.VSlider(
             # Opacity
             v_model=("contour_opacity", 1.0),
             min=0,
@@ -568,21 +582,21 @@ with SinglePageWithDrawerLayout(server) as layout:
 
     with layout.toolbar:
         # toolbar components
-        vuetify.VSpacer()
-        vuetify.VDivider(vertical=True, classes="mx-2")
+        vuetify3.VSpacer()
+        vuetify3.VDivider(vertical=True, classes="mx-2")
         standard_buttons()
 
     with layout.drawer as drawer:
         # drawer components
         drawer.width = 325
         pipeline_widget()
-        vuetify.VDivider(classes="mb-2")
+        vuetify3.VDivider(classes="mb-2")
         mesh_card()
         contour_card()
 
     with layout.content:
         # content components
-        with vuetify.VContainer(
+        with vuetify3.VContainer(
             fluid=True,
             classes="pa-0 fill-height",
         ):

--- a/04_application/solution.py
+++ b/04_application/solution.py
@@ -1,8 +1,10 @@
 import os
 
-from trame.app import get_server
+from trame.app import TrameApp
 from trame.ui.vuetify3 import SinglePageWithDrawerLayout
-from trame.widgets import vtk, vuetify3, trame
+from trame.widgets import vuetify3 as v3
+from trame.widgets import vtk, trame
+from trame.decorators import change
 
 from trame_vtk.modules.vtk.serializers import configure_serializer
 
@@ -174,177 +176,177 @@ renderer.ResetCamera()
 # Trame setup
 # -----------------------------------------------------------------------------
 
-server = get_server()
-state, ctrl = server.state, server.controller
-
-state.setdefault("active_ui", None)
+class App(TrameApp):
+    def __init__(self, server=None):
+        super().__init__(server)
+        self._build_ui()
+        self.state.setdefault("active_ui", None)
 
 # -----------------------------------------------------------------------------
 # Callbacks
 # -----------------------------------------------------------------------------
 
-
-@state.change("cube_axes_visibility")
-def update_cube_axes_visibility(cube_axes_visibility, **kwargs):
-    cube_axes.SetVisibility(cube_axes_visibility)
-    ctrl.view_update()
-
-
-# Selection Change
-def actives_change(ids):
-    _id = ids[0]
-    if _id == "1":  # Mesh
-        state.active_ui = "mesh"
-    elif _id == "2":  # Contour
-        state.active_ui = "contour"
-    else:
-        state.active_ui = "nothing"
+    @change("cube_axes_visibility")
+    def update_cube_axes_visibility(self, cube_axes_visibility, **kwargs):
+        cube_axes.SetVisibility(cube_axes_visibility)
+        self.ctrl.view_update()
 
 
-# Visibility Change
-def visibility_change(event):
-    _id = event["id"]
-    _visibility = event["visible"]
-
-    if _id == "1":  # Mesh
-        mesh_actor.SetVisibility(_visibility)
-    elif _id == "2":  # Contour
-        contour_actor.SetVisibility(_visibility)
-    ctrl.view_update()
-
-
-# Representation Callbacks
-def update_representation(actor, mode):
-    property = actor.GetProperty()
-    if mode == Representation.Points:
-        property.SetRepresentationToPoints()
-        property.SetPointSize(5)
-        property.EdgeVisibilityOff()
-    elif mode == Representation.Wireframe:
-        property.SetRepresentationToWireframe()
-        property.SetPointSize(1)
-        property.EdgeVisibilityOff()
-    elif mode == Representation.Surface:
-        property.SetRepresentationToSurface()
-        property.SetPointSize(1)
-        property.EdgeVisibilityOff()
-    elif mode == Representation.SurfaceWithEdges:
-        property.SetRepresentationToSurface()
-        property.SetPointSize(1)
-        property.EdgeVisibilityOn()
+    # Selection Change
+    def actives_change(self, ids):
+        _id = ids[0]
+        if _id == "1":  # Mesh
+            self.state.active_ui = "mesh"
+        elif _id == "2":  # Contour
+            self.state.active_ui = "contour"
+        else:
+            self.state.active_ui = "nothing"
 
 
-@state.change("mesh_representation")
-def update_mesh_representation(mesh_representation, **kwargs):
-    update_representation(mesh_actor, mesh_representation)
-    ctrl.view_update()
+    # Visibility Change
+    def visibility_change(self, event):
+        _id = event["id"]
+        _visibility = event["visible"]
+
+        if _id == "1":  # Mesh
+            mesh_actor.SetVisibility(_visibility)
+        elif _id == "2":  # Contour
+            contour_actor.SetVisibility(_visibility)
+        self.ctrl.view_update()
 
 
-@state.change("contour_representation")
-def update_contour_representation(contour_representation, **kwargs):
-    update_representation(contour_actor, contour_representation)
-    ctrl.view_update()
+    # Representation Callbacks
+    def update_representation(self, actor, mode):
+        property = actor.GetProperty()
+        if mode == Representation.Points:
+            property.SetRepresentationToPoints()
+            property.SetPointSize(5)
+            property.EdgeVisibilityOff()
+        elif mode == Representation.Wireframe:
+            property.SetRepresentationToWireframe()
+            property.SetPointSize(1)
+            property.EdgeVisibilityOff()
+        elif mode == Representation.Surface:
+            property.SetRepresentationToSurface()
+            property.SetPointSize(1)
+            property.EdgeVisibilityOff()
+        elif mode == Representation.SurfaceWithEdges:
+            property.SetRepresentationToSurface()
+            property.SetPointSize(1)
+            property.EdgeVisibilityOn()
 
 
-# Color By Callbacks
-def color_by_array(actor, array):
-    _min, _max = array.get("range")
-    mapper = actor.GetMapper()
-    mapper.SelectColorArray(array.get("text"))
-    mapper.GetLookupTable().SetRange(_min, _max)
-    if array.get("type") == vtkDataObject.FIELD_ASSOCIATION_POINTS:
-        mesh_mapper.SetScalarModeToUsePointFieldData()
-    else:
-        mesh_mapper.SetScalarModeToUseCellFieldData()
-    mapper.SetScalarVisibility(True)
-    mapper.SetUseLookupTableScalarRange(True)
+    @change("mesh_representation")
+    def update_mesh_representation(self, mesh_representation, **kwargs):
+        self.update_representation(mesh_actor, mesh_representation)
+        self.ctrl.view_update()
 
 
-@state.change("mesh_color_array_idx")
-def update_mesh_color_by_name(mesh_color_array_idx, **kwargs):
-    array = dataset_arrays[mesh_color_array_idx]
-    color_by_array(mesh_actor, array)
-    ctrl.view_update()
+    @change("contour_representation")
+    def update_contour_representation(self, contour_representation, **kwargs):
+        self.update_representation(contour_actor, contour_representation)
+        self.ctrl.view_update()
 
 
-@state.change("contour_color_array_idx")
-def update_contour_color_by_name(contour_color_array_idx, **kwargs):
-    array = dataset_arrays[contour_color_array_idx]
-    color_by_array(contour_actor, array)
-    ctrl.view_update()
+    # Color By Callbacks
+    def color_by_array(self, actor, array):
+        _min, _max = array.get("range")
+        mapper = actor.GetMapper()
+        mapper.SelectColorArray(array.get("text"))
+        mapper.GetLookupTable().SetRange(_min, _max)
+        if array.get("type") == vtkDataObject.FIELD_ASSOCIATION_POINTS:
+            mesh_mapper.SetScalarModeToUsePointFieldData()
+        else:
+            mesh_mapper.SetScalarModeToUseCellFieldData()
+        mapper.SetScalarVisibility(True)
+        mapper.SetUseLookupTableScalarRange(True)
 
 
-# Color Map Callbacks
-def use_preset(actor, preset):
-    lut = actor.GetMapper().GetLookupTable()
-    if preset == LookupTable.Rainbow:
-        lut.SetHueRange(0.666, 0.0)
-        lut.SetSaturationRange(1.0, 1.0)
-        lut.SetValueRange(1.0, 1.0)
-    elif preset == LookupTable.Inverted_Rainbow:
-        lut.SetHueRange(0.0, 0.666)
-        lut.SetSaturationRange(1.0, 1.0)
-        lut.SetValueRange(1.0, 1.0)
-    elif preset == LookupTable.Greyscale:
-        lut.SetHueRange(0.0, 0.0)
-        lut.SetSaturationRange(0.0, 0.0)
-        lut.SetValueRange(0.0, 1.0)
-    elif preset == LookupTable.Inverted_Greyscale:
-        lut.SetHueRange(0.0, 0.666)
-        lut.SetSaturationRange(0.0, 0.0)
-        lut.SetValueRange(1.0, 0.0)
-    lut.Build()
+    @change("mesh_color_array_idx")
+    def update_mesh_color_by_name(self, mesh_color_array_idx, **kwargs):
+        array = dataset_arrays[mesh_color_array_idx]
+        self.color_by_array(mesh_actor, array)
+        self.ctrl.view_update()
 
 
-@state.change("mesh_color_preset")
-def update_mesh_color_preset(mesh_color_preset, **kwargs):
-    use_preset(mesh_actor, mesh_color_preset)
-    ctrl.view_update()
+    @change("contour_color_array_idx")
+    def update_contour_color_by_name(self, contour_color_array_idx, **kwargs):
+        array = dataset_arrays[contour_color_array_idx]
+        self.color_by_array(contour_actor, array)
+        self.ctrl.view_update()
 
 
-@state.change("contour_color_preset")
-def update_contour_color_preset(contour_color_preset, **kwargs):
-    use_preset(contour_actor, contour_color_preset)
-    ctrl.view_update()
+    # Color Map Callbacks
+    def use_preset(self, actor, preset):
+        lut = actor.GetMapper().GetLookupTable()
+        if preset == LookupTable.Rainbow:
+            lut.SetHueRange(0.666, 0.0)
+            lut.SetSaturationRange(1.0, 1.0)
+            lut.SetValueRange(1.0, 1.0)
+        elif preset == LookupTable.Inverted_Rainbow:
+            lut.SetHueRange(0.0, 0.666)
+            lut.SetSaturationRange(1.0, 1.0)
+            lut.SetValueRange(1.0, 1.0)
+        elif preset == LookupTable.Greyscale:
+            lut.SetHueRange(0.0, 0.0)
+            lut.SetSaturationRange(0.0, 0.0)
+            lut.SetValueRange(0.0, 1.0)
+        elif preset == LookupTable.Inverted_Greyscale:
+            lut.SetHueRange(0.0, 0.666)
+            lut.SetSaturationRange(0.0, 0.0)
+            lut.SetValueRange(1.0, 0.0)
+        lut.Build()
 
 
-# Opacity Callbacks
-@state.change("mesh_opacity")
-def update_mesh_opacity(mesh_opacity, **kwargs):
-    mesh_actor.GetProperty().SetOpacity(mesh_opacity)
-    ctrl.view_update()
+    @change("mesh_color_preset")
+    def update_mesh_color_preset(self, mesh_color_preset, **kwargs):
+        self.use_preset(mesh_actor, mesh_color_preset)
+        self.ctrl.view_update()
 
 
-@state.change("contour_opacity")
-def update_contour_opacity(contour_opacity, **kwargs):
-    contour_actor.GetProperty().SetOpacity(contour_opacity)
-    ctrl.view_update()
+    @change("contour_color_preset")
+    def update_contour_color_preset(self, contour_color_preset, **kwargs):
+        self.use_preset(contour_actor, contour_color_preset)
+        self.ctrl.view_update()
 
 
-# Contour Callbacks
-@state.change("contour_by_array_idx")
-def update_contour_by(contour_by_array_idx, **kwargs):
-    array = dataset_arrays[contour_by_array_idx]
-    contour_min, contour_max = array.get("range")
-    contour_step = 0.01 * (contour_max - contour_min)
-    contour_value = 0.5 * (contour_max + contour_min)
-    contour.SetInputArrayToProcess(0, 0, 0, array.get("type"), array.get("text"))
-    contour.SetValue(0, contour_value)
-
-    # Update UI
-    state.contour_min = contour_min
-    state.contour_max = contour_max
-    state.contour_value = contour_value
-    state.contour_step = contour_step
-
-    # Update View
-    ctrl.view_update()
+    # Opacity Callbacks
+    @change("mesh_opacity")
+    def update_mesh_opacity(self, mesh_opacity, **kwargs):
+        mesh_actor.GetProperty().SetOpacity(mesh_opacity)
+        self.ctrl.view_update()
 
 
-@state.change("contour_value")
-def update_contour_value(contour_value, **kwargs):
-    contour.SetValue(0, float(contour_value))
-    ctrl.view_update()
+    @change("contour_opacity")
+    def update_contour_opacity(self, contour_opacity, **kwargs):
+        contour_actor.GetProperty().SetOpacity(contour_opacity)
+        self.ctrl.view_update()
+
+
+    # Contour Callbacks
+    @change("contour_by_array_idx")
+    def update_contour_by(self, contour_by_array_idx, **kwargs):
+        array = dataset_arrays[contour_by_array_idx]
+        contour_min, contour_max = array.get("range")
+        contour_step = 0.01 * (contour_max - contour_min)
+        contour_value = 0.5 * (contour_max + contour_min)
+        contour.SetInputArrayToProcess(0, 0, 0, array.get("type"), array.get("text"))
+        contour.SetValue(0, contour_value)
+
+        # Update UI
+        self.state.contour_min = contour_min
+        self.state.contour_max = contour_max
+        self.state.contour_value = contour_value
+        self.state.contour_step = contour_step
+
+        # Update View
+        self.ctrl.view_update()
+
+
+    @change("contour_value")
+    def update_contour_value(self, contour_value, **kwargs):
+        contour.SetValue(0, float(contour_value))
+        self.ctrl.view_update()
 
 
 # -----------------------------------------------------------------------------
@@ -352,267 +354,272 @@ def update_contour_value(contour_value, **kwargs):
 # -----------------------------------------------------------------------------
 
 
-def standard_buttons():
-    vuetify3.VCheckbox(
-        v_model=("cube_axes_visibility", True),
-        true_icon="mdi-cube-outline",
-        false_icon="mdi-cube-off-outline",
-        classes="mx-1",
-        hide_details=True,
-        dense=True,
-    )
-    vuetify3.VCheckbox(
-        v_model="theme",
-        true_value="dark",
-        false_value="light",
-        true_icon="mdi-lightbulb-off-outline",
-        false_icon="mdi-lightbulb-outline",
-        classes="mx-1",
-        hide_details=True,
-        dense=True,
-    )
-    vuetify3.VCheckbox(
-        v_model=("viewMode", "local"),
-        true_icon="mdi-lan-disconnect",
-        false_icon="mdi-lan-connect",
-        true_value="local",
-        false_value="remote",
-        classes="mx-1",
-        hide_details=True,
-        dense=True,
-    )
-    with vuetify3.VBtn(icon=True, click=ctrl.view_reset_camera):
-        vuetify3.VIcon("mdi-crop-free")
-
-
-def pipeline_widget():
-    trame.GitTree(
-        sources=(
-            "pipeline",
-            [
-                {"id": "1", "parent": "0", "visible": 1, "name": "Mesh"},
-                {"id": "2", "parent": "1", "visible": 1, "name": "Contour"},
-            ],
-        ),
-        actives_change=(actives_change, "[$event]"),
-        visibility_change=(visibility_change, "[$event]"),
-    )
-
-
-def ui_card(title, ui_name):
-    with vuetify3.VCard(v_show=f"active_ui == '{ui_name}'"):
-        vuetify3.VCardTitle(
-            title,
-            classes="grey lighten-1 py-1 grey--text text--darken-3",
-            style="user-select: none; cursor: pointer",
+    def standard_buttons(self):
+        v3.VCheckbox(
+            v_model=("cube_axes_visibility", True),
+            true_icon="mdi-cube-outline",
+            false_icon="mdi-cube-off-outline",
+            classes="mx-1",
             hide_details=True,
             dense=True,
         )
-        content = vuetify3.VCardText(classes="py-2")
-    return content
+        v3.VCheckbox(
+            v_model="theme",
+            true_value="dark",
+            false_value="light",
+            true_icon="mdi-lightbulb-off-outline",
+            false_icon="mdi-lightbulb-outline",
+            classes="mx-1",
+            hide_details=True,
+            dense=True,
+        )
+        v3.VCheckbox(
+            v_model=("viewMode", "local"),
+            true_icon="mdi-lan-disconnect",
+            false_icon="mdi-lan-connect",
+            true_value="local",
+            false_value="remote",
+            classes="mx-1",
+            hide_details=True,
+            dense=True,
+        )
+        with v3.VBtn(icon=True, click=self.ctrl.view_reset_camera):
+            v3.VIcon("mdi-crop-free")
 
 
-def mesh_card():
-    with ui_card(title="Mesh", ui_name="mesh"):
-        vuetify3.VSelect(
-            # Representation
-            v_model=("mesh_representation", Representation.Surface),
-            items=(
-                "representations",
+    def pipeline_widget(self):
+        trame.GitTree(
+            sources=(
+                "pipeline",
                 [
-                    {"text": "Points", "value": 0},
-                    {"text": "Wireframe", "value": 1},
-                    {"text": "Surface", "value": 2},
-                    {"text": "SurfaceWithEdges", "value": 3},
+                    {"id": "1", "parent": "0", "visible": 1, "name": "Mesh"},
+                    {"id": "2", "parent": "1", "visible": 1, "name": "Contour"},
                 ],
             ),
-            item_title="text",
-            item_value="value",
-            label="Representation",
-            hide_details=True,
-            dense=True,
-            outlined=True,
-            classes="pt-1",
-        )
-        with vuetify3.VRow(classes="pt-2", dense=True):
-            with vuetify3.VCol(cols="6"):
-                vuetify3.VSelect(
-                    # Color By
-                    label="Color by",
-                    v_model=("mesh_color_array_idx", 0),
-                    items=("array_list", dataset_arrays),
-                    item_title="text",
-                    item_value="value",
-                    hide_details=True,
-                    dense=True,
-                    outlined=True,
-                    classes="pt-1",
-                )
-            with vuetify3.VCol(cols="6"):
-                vuetify3.VSelect(
-                    # Color Map
-                    label="Colormap",
-                    v_model=("mesh_color_preset", LookupTable.Rainbow),
-                    items=(
-                        "colormaps",
-                        [
-                            {"text": "Rainbow", "value": 0},
-                            {"text": "Inv Rainbow", "value": 1},
-                            {"text": "Greyscale", "value": 2},
-                            {"text": "Inv Greyscale", "value": 3},
-                        ],
-                    ),
-                    item_title="text",
-                    item_value="value",
-                    hide_details=True,
-                    dense=True,
-                    outlined=True,
-                    classes="pt-1",
-                )
-        vuetify3.VSlider(
-            # Opacity
-            v_model=("mesh_opacity", 1.0),
-            min=0,
-            max=1,
-            step=0.1,
-            label="Opacity",
-            classes="mt-1",
-            hide_details=True,
-            dense=True,
+            actives_change=(self.actives_change, "[$event]"),
+            visibility_change=(self.visibility_change, "[$event]"),
         )
 
 
-def contour_card():
-    with ui_card(title="Contour", ui_name="contour"):
-        vuetify3.VSelect(
-            # Contour By
-            label="Contour by",
-            v_model=("contour_by_array_idx", 0),
-            items=("array_list", dataset_arrays),
-            item_title="text",
-            item_value="value",
-            hide_details=True,
-            dense=True,
-            outlined=True,
-            classes="pt-1",
-        )
-        vuetify3.VSlider(
-            # Contour Value
-            v_model=("contour_value", contour_value),
-            min=("contour_min", default_min),
-            max=("contour_max", default_max),
-            step=("contour_step", 0.01 * (default_max - default_min)),
-            label="Value",
-            classes="my-1",
-            hide_details=True,
-            dense=True,
-        )
-        vuetify3.VSelect(
-            # Representation
-            v_model=("contour_representation", Representation.Surface),
-            items=(
-                "representations",
-                [
-                    {"text": "Points", "value": 0},
-                    {"text": "Wireframe", "value": 1},
-                    {"text": "Surface", "value": 2},
-                    {"text": "SurfaceWithEdges", "value": 3},
-                ],
-            ),
-            item_title="text",
-            item_value="value",
-            label="Representation",
-            hide_details=True,
-            dense=True,
-            outlined=True,
-            classes="pt-1",
-        )
-        with vuetify3.VRow(classes="pt-2", dense=True):
-            with vuetify3.VCol(cols="6"):
-                vuetify3.VSelect(
-                    # Color By
-                    label="Color by",
-                    v_model=("contour_color_array_idx", 0),
-                    items=("array_list", dataset_arrays),
-                    item_title="text",
-                    item_value="value",
-                    hide_details=True,
-                    dense=True,
-                    outlined=True,
-                    classes="pt-1",
-                )
-            with vuetify3.VCol(cols="6"):
-                vuetify3.VSelect(
-                    # Color Map
-                    label="Colormap",
-                    v_model=("contour_color_preset", LookupTable.Rainbow),
-                    items=(
-                        "colormaps",
-                        [
-                            {"text": "Rainbow", "value": 0},
-                            {"text": "Inv Rainbow", "value": 1},
-                            {"text": "Greyscale", "value": 2},
-                            {"text": "Inv Greyscale", "value": 3},
-                        ],
-                    ),
-                    item_title="text",
-                    item_value="value",
-                    hide_details=True,
-                    dense=True,
-                    outlined=True,
-                    classes="pt-1",
-                )
-        vuetify3.VSlider(
-            # Opacity
-            v_model=("contour_opacity", 1.0),
-            min=0,
-            max=1,
-            step=0.1,
-            label="Opacity",
-            classes="mt-1",
-            hide_details=True,
-            dense=True,
-        )
+    def ui_card(self, title, ui_name):
+        with v3.VCard(v_show=f"active_ui == '{ui_name}'"):
+            v3.VCardTitle(
+                title,
+                classes="grey lighten-1 py-1 grey--text text--darken-3",
+                style="user-select: none; cursor: pointer",
+                hide_details=True,
+                dense=True,
+            )
+            content = v3.VCardText(classes="py-2")
+        return content
+
+
+    def mesh_card(self):
+        with self.ui_card(title="Mesh", ui_name="mesh"):
+            v3.VSelect(
+                # Representation
+                v_model=("mesh_representation", Representation.Surface),
+                items=(
+                    "representations",
+                    [
+                        {"text": "Points", "value": 0},
+                        {"text": "Wireframe", "value": 1},
+                        {"text": "Surface", "value": 2},
+                        {"text": "SurfaceWithEdges", "value": 3},
+                    ],
+                ),
+                item_title="text",
+                item_value="value",
+                label="Representation",
+                hide_details=True,
+                dense=True,
+                outlined=True,
+                classes="pt-1",
+            )
+            with v3.VRow(classes="pt-2", dense=True):
+                with v3.VCol(cols="6"):
+                    v3.VSelect(
+                        # Color By
+                        label="Color by",
+                        v_model=("mesh_color_array_idx", 0),
+                        items=("array_list", dataset_arrays),
+                        item_title="text",
+                        item_value="value",
+                        hide_details=True,
+                        dense=True,
+                        outlined=True,
+                        classes="pt-1",
+                    )
+                with v3.VCol(cols="6"):
+                    v3.VSelect(
+                        # Color Map
+                        label="Colormap",
+                        v_model=("mesh_color_preset", LookupTable.Rainbow),
+                        items=(
+                            "colormaps",
+                            [
+                                {"text": "Rainbow", "value": 0},
+                                {"text": "Inv Rainbow", "value": 1},
+                                {"text": "Greyscale", "value": 2},
+                                {"text": "Inv Greyscale", "value": 3},
+                            ],
+                        ),
+                        item_title="text",
+                        item_value="value",
+                        hide_details=True,
+                        dense=True,
+                        outlined=True,
+                        classes="pt-1",
+                    )
+            v3.VSlider(
+                # Opacity
+                v_model=("mesh_opacity", 1.0),
+                min=0,
+                max=1,
+                step=0.1,
+                label="Opacity",
+                classes="mt-1",
+                hide_details=True,
+                dense=True,
+            )
+
+
+    def contour_card(self):
+        with self.ui_card(title="Contour", ui_name="contour"):
+            v3.VSelect(
+                # Contour By
+                label="Contour by",
+                v_model=("contour_by_array_idx", 0),
+                items=("array_list", dataset_arrays),
+                item_title="text",
+                item_value="value",
+                hide_details=True,
+                dense=True,
+                outlined=True,
+                classes="pt-1",
+            )
+            v3.VSlider(
+                # Contour Value
+                v_model=("contour_value", contour_value),
+                min=("contour_min", default_min),
+                max=("contour_max", default_max),
+                step=("contour_step", 0.01 * (default_max - default_min)),
+                label="Value",
+                classes="my-1",
+                hide_details=True,
+                dense=True,
+            )
+            v3.VSelect(
+                # Representation
+                v_model=("contour_representation", Representation.Surface),
+                items=(
+                    "representations",
+                    [
+                        {"text": "Points", "value": 0},
+                        {"text": "Wireframe", "value": 1},
+                        {"text": "Surface", "value": 2},
+                        {"text": "SurfaceWithEdges", "value": 3},
+                    ],
+                ),
+                item_title="text",
+                item_value="value",
+                label="Representation",
+                hide_details=True,
+                dense=True,
+                outlined=True,
+                classes="pt-1",
+            )
+            with v3.VRow(classes="pt-2", dense=True):
+                with v3.VCol(cols="6"):
+                    v3.VSelect(
+                        # Color By
+                        label="Color by",
+                        v_model=("contour_color_array_idx", 0),
+                        items=("array_list", dataset_arrays),
+                        item_title="text",
+                        item_value="value",
+                        hide_details=True,
+                        dense=True,
+                        outlined=True,
+                        classes="pt-1",
+                    )
+                with v3.VCol(cols="6"):
+                    v3.VSelect(
+                        # Color Map
+                        label="Colormap",
+                        v_model=("contour_color_preset", LookupTable.Rainbow),
+                        items=(
+                            "colormaps",
+                            [
+                                {"text": "Rainbow", "value": 0},
+                                {"text": "Inv Rainbow", "value": 1},
+                                {"text": "Greyscale", "value": 2},
+                                {"text": "Inv Greyscale", "value": 3},
+                            ],
+                        ),
+                        item_title="text",
+                        item_value="value",
+                        hide_details=True,
+                        dense=True,
+                        outlined=True,
+                        classes="pt-1",
+                    )
+            v3.VSlider(
+                # Opacity
+                v_model=("contour_opacity", 1.0),
+                min=0,
+                max=1,
+                step=0.1,
+                label="Opacity",
+                classes="mt-1",
+                hide_details=True,
+                dense=True,
+            )
 
 
 # -----------------------------------------------------------------------------
 # GUI
 # -----------------------------------------------------------------------------
 
-with SinglePageWithDrawerLayout(server, theme=("theme", "light")) as layout:
-    layout.title.set_text("Viewer")
+    def _build_ui(self):
+        with SinglePageWithDrawerLayout(self.server, theme=("theme", "light")) as self.ui:
+            self.ui.title.set_text("Viewer")
 
-    with layout.toolbar:
-        # toolbar components
-        vuetify3.VSpacer()
-        vuetify3.VDivider(vertical=True, classes="mx-2")
-        standard_buttons()
+            with self.ui.toolbar:
+                # toolbar components
+                v3.VSpacer()
+                v3.VDivider(vertical=True, classes="mx-2")
+                self.standard_buttons()
 
-    with layout.drawer as drawer:
-        # drawer components
-        drawer.width = 325
-        pipeline_widget()
-        vuetify3.VDivider(classes="mb-2")
-        mesh_card()
-        contour_card()
+            with self.ui.drawer as drawer:
+                # drawer components
+                drawer.width = 325
+                self.pipeline_widget()
+                v3.VDivider(classes="mb-2")
+                self.mesh_card()
+                self.contour_card()
 
-    with layout.content:
-        # content components
-        with vuetify3.VContainer(
-            fluid=True,
-            classes="pa-0 fill-height",
-        ):
-            # view = vtk.VtkRemoteView(renderWindow, interactive_ratio=1)
-            # view = vtk.VtkLocalView(renderWindow)
-            view = vtk.VtkRemoteLocalView(
-                renderWindow, namespace="view", mode="local", interactive_ratio=1
-            )
-            ctrl.view_update = view.update
-            ctrl.view_reset_camera = view.reset_camera
+            with self.ui.content:
+                # content components
+                with v3.VContainer(
+                    fluid=True,
+                    classes="pa-0 fill-height",
+                ):
+                    # view = vtk.VtkRemoteView(renderWindow, interactive_ratio=1)
+                    # view = vtk.VtkLocalView(renderWindow)
+                    view = vtk.VtkRemoteLocalView(
+                        renderWindow, namespace="view", mode="local", interactive_ratio=1
+                    )
+                    self.ctrl.view_update = view.update
+                    self.ctrl.view_reset_camera = view.reset_camera
 
 # -----------------------------------------------------------------------------
 # Main
 # -----------------------------------------------------------------------------
 
+def main():
+    app = App()
+    app.server.start()
+
 if __name__ == "__main__":
-    server.start()
+    main()

--- a/04_application/solution.py
+++ b/04_application/solution.py
@@ -2,7 +2,7 @@ import os
 
 from trame.app import get_server
 from trame.ui.vuetify3 import SinglePageWithDrawerLayout
-from trame.widgets import vtk, vuetify3 as vuetify, trame
+from trame.widgets import vtk, vuetify3, trame
 
 from trame_vtk.modules.vtk.serializers import configure_serializer
 
@@ -353,7 +353,7 @@ def update_contour_value(contour_value, **kwargs):
 
 
 def standard_buttons():
-    vuetify.VCheckbox(
+    vuetify3.VCheckbox(
         v_model=("cube_axes_visibility", True),
         true_icon="mdi-cube-outline",
         false_icon="mdi-cube-off-outline",
@@ -361,7 +361,7 @@ def standard_buttons():
         hide_details=True,
         dense=True,
     )
-    vuetify.VCheckbox(
+    vuetify3.VCheckbox(
         v_model="theme",
         true_value="dark",
         false_value="light",
@@ -371,7 +371,7 @@ def standard_buttons():
         hide_details=True,
         dense=True,
     )
-    vuetify.VCheckbox(
+    vuetify3.VCheckbox(
         v_model=("viewMode", "local"),
         true_icon="mdi-lan-disconnect",
         false_icon="mdi-lan-connect",
@@ -381,8 +381,8 @@ def standard_buttons():
         hide_details=True,
         dense=True,
     )
-    with vuetify.VBtn(icon=True, click=ctrl.view_reset_camera):
-        vuetify.VIcon("mdi-crop-free")
+    with vuetify3.VBtn(icon=True, click=ctrl.view_reset_camera):
+        vuetify3.VIcon("mdi-crop-free")
 
 
 def pipeline_widget():
@@ -400,21 +400,21 @@ def pipeline_widget():
 
 
 def ui_card(title, ui_name):
-    with vuetify.VCard(v_show=f"active_ui == '{ui_name}'"):
-        vuetify.VCardTitle(
+    with vuetify3.VCard(v_show=f"active_ui == '{ui_name}'"):
+        vuetify3.VCardTitle(
             title,
             classes="grey lighten-1 py-1 grey--text text--darken-3",
             style="user-select: none; cursor: pointer",
             hide_details=True,
             dense=True,
         )
-        content = vuetify.VCardText(classes="py-2")
+        content = vuetify3.VCardText(classes="py-2")
     return content
 
 
 def mesh_card():
     with ui_card(title="Mesh", ui_name="mesh"):
-        vuetify.VSelect(
+        vuetify3.VSelect(
             # Representation
             v_model=("mesh_representation", Representation.Surface),
             items=(
@@ -434,9 +434,9 @@ def mesh_card():
             outlined=True,
             classes="pt-1",
         )
-        with vuetify.VRow(classes="pt-2", dense=True):
-            with vuetify.VCol(cols="6"):
-                vuetify.VSelect(
+        with vuetify3.VRow(classes="pt-2", dense=True):
+            with vuetify3.VCol(cols="6"):
+                vuetify3.VSelect(
                     # Color By
                     label="Color by",
                     v_model=("mesh_color_array_idx", 0),
@@ -448,8 +448,8 @@ def mesh_card():
                     outlined=True,
                     classes="pt-1",
                 )
-            with vuetify.VCol(cols="6"):
-                vuetify.VSelect(
+            with vuetify3.VCol(cols="6"):
+                vuetify3.VSelect(
                     # Color Map
                     label="Colormap",
                     v_model=("mesh_color_preset", LookupTable.Rainbow),
@@ -469,7 +469,7 @@ def mesh_card():
                     outlined=True,
                     classes="pt-1",
                 )
-        vuetify.VSlider(
+        vuetify3.VSlider(
             # Opacity
             v_model=("mesh_opacity", 1.0),
             min=0,
@@ -484,7 +484,7 @@ def mesh_card():
 
 def contour_card():
     with ui_card(title="Contour", ui_name="contour"):
-        vuetify.VSelect(
+        vuetify3.VSelect(
             # Contour By
             label="Contour by",
             v_model=("contour_by_array_idx", 0),
@@ -496,7 +496,7 @@ def contour_card():
             outlined=True,
             classes="pt-1",
         )
-        vuetify.VSlider(
+        vuetify3.VSlider(
             # Contour Value
             v_model=("contour_value", contour_value),
             min=("contour_min", default_min),
@@ -507,7 +507,7 @@ def contour_card():
             hide_details=True,
             dense=True,
         )
-        vuetify.VSelect(
+        vuetify3.VSelect(
             # Representation
             v_model=("contour_representation", Representation.Surface),
             items=(
@@ -527,9 +527,9 @@ def contour_card():
             outlined=True,
             classes="pt-1",
         )
-        with vuetify.VRow(classes="pt-2", dense=True):
-            with vuetify.VCol(cols="6"):
-                vuetify.VSelect(
+        with vuetify3.VRow(classes="pt-2", dense=True):
+            with vuetify3.VCol(cols="6"):
+                vuetify3.VSelect(
                     # Color By
                     label="Color by",
                     v_model=("contour_color_array_idx", 0),
@@ -541,8 +541,8 @@ def contour_card():
                     outlined=True,
                     classes="pt-1",
                 )
-            with vuetify.VCol(cols="6"):
-                vuetify.VSelect(
+            with vuetify3.VCol(cols="6"):
+                vuetify3.VSelect(
                     # Color Map
                     label="Colormap",
                     v_model=("contour_color_preset", LookupTable.Rainbow),
@@ -562,7 +562,7 @@ def contour_card():
                     outlined=True,
                     classes="pt-1",
                 )
-        vuetify.VSlider(
+        vuetify3.VSlider(
             # Opacity
             v_model=("contour_opacity", 1.0),
             min=0,
@@ -584,21 +584,21 @@ with SinglePageWithDrawerLayout(server, theme=("theme", "light")) as layout:
 
     with layout.toolbar:
         # toolbar components
-        vuetify.VSpacer()
-        vuetify.VDivider(vertical=True, classes="mx-2")
+        vuetify3.VSpacer()
+        vuetify3.VDivider(vertical=True, classes="mx-2")
         standard_buttons()
 
     with layout.drawer as drawer:
         # drawer components
         drawer.width = 325
         pipeline_widget()
-        vuetify.VDivider(classes="mb-2")
+        vuetify3.VDivider(classes="mb-2")
         mesh_card()
         contour_card()
 
     with layout.content:
         # content components
-        with vuetify.VContainer(
+        with vuetify3.VContainer(
             fluid=True,
             classes="pa-0 fill-height",
         ):

--- a/04_application/solution.py
+++ b/04_application/solution.py
@@ -367,7 +367,7 @@ class App(TrameApp):
             false_icon="mdi-cube-off-outline",
             classes="mx-1",
             hide_details=True,
-            dense=True,
+            density="compact",
         )
         v3.VCheckbox(
             v_model="theme",
@@ -377,7 +377,7 @@ class App(TrameApp):
             false_icon="mdi-lightbulb-outline",
             classes="mx-1",
             hide_details=True,
-            dense=True,
+            density="compact",
         )
         v3.VCheckbox(
             v_model=("viewMode", "local"),
@@ -387,7 +387,7 @@ class App(TrameApp):
             false_value="remote",
             classes="mx-1",
             hide_details=True,
-            dense=True,
+            density="compact",
         )
         with v3.VBtn(icon=True, click=self.ctrl.view_reset_camera):
             v3.VIcon("mdi-crop-free")
@@ -414,7 +414,7 @@ class App(TrameApp):
                 classes="grey lighten-1 py-1 grey--text text--darken-3",
                 style="user-select: none; cursor: pointer",
                 hide_details=True,
-                dense=True,
+                density="compact",
             )
             content = v3.VCardText(classes="py-2")
         return content
@@ -438,11 +438,11 @@ class App(TrameApp):
                 item_value="value",
                 label="Representation",
                 hide_details=True,
-                dense=True,
+                density="compact",
                 outlined=True,
                 classes="pt-1",
             )
-            with v3.VRow(classes="pt-2", dense=True):
+            with v3.VRow(classes="pt-2", density="compact"):
                 with v3.VCol(cols="6"):
                     v3.VSelect(
                         # Color By
@@ -452,7 +452,7 @@ class App(TrameApp):
                         item_title="text",
                         item_value="value",
                         hide_details=True,
-                        dense=True,
+                        density="compact",
                         outlined=True,
                         classes="pt-1",
                     )
@@ -473,7 +473,7 @@ class App(TrameApp):
                         item_title="text",
                         item_value="value",
                         hide_details=True,
-                        dense=True,
+                        density="compact",
                         outlined=True,
                         classes="pt-1",
                     )
@@ -486,7 +486,7 @@ class App(TrameApp):
                 label="Opacity",
                 classes="mt-1",
                 hide_details=True,
-                dense=True,
+                density="compact",
             )
 
 
@@ -500,7 +500,7 @@ class App(TrameApp):
                 item_title="text",
                 item_value="value",
                 hide_details=True,
-                dense=True,
+                density="compact",
                 outlined=True,
                 classes="pt-1",
             )
@@ -513,7 +513,7 @@ class App(TrameApp):
                 label="Value",
                 classes="my-1",
                 hide_details=True,
-                dense=True,
+                density="compact",
             )
             v3.VSelect(
                 # Representation
@@ -531,11 +531,11 @@ class App(TrameApp):
                 item_value="value",
                 label="Representation",
                 hide_details=True,
-                dense=True,
+                density="compact",
                 outlined=True,
                 classes="pt-1",
             )
-            with v3.VRow(classes="pt-2", dense=True):
+            with v3.VRow(classes="pt-2", density="compact"):
                 with v3.VCol(cols="6"):
                     v3.VSelect(
                         # Color By
@@ -545,7 +545,7 @@ class App(TrameApp):
                         item_title="text",
                         item_value="value",
                         hide_details=True,
-                        dense=True,
+                        density="compact",
                         outlined=True,
                         classes="pt-1",
                     )
@@ -566,7 +566,7 @@ class App(TrameApp):
                         item_title="text",
                         item_value="value",
                         hide_details=True,
-                        dense=True,
+                        density="compact",
                         outlined=True,
                         classes="pt-1",
                     )
@@ -579,7 +579,7 @@ class App(TrameApp):
                 label="Opacity",
                 classes="mt-1",
                 hide_details=True,
-                dense=True,
+                density="compact",
             )
 
 

--- a/05_paraview/SimpleCone.py
+++ b/05_paraview/SimpleCone.py
@@ -1,7 +1,7 @@
 import paraview.web.venv  # Available in PV 5.10
 
 from trame.app import get_server
-from trame.widgets import vuetify3, paraview
+from trame.widgets import vuetify3 as vuetify, paraview
 from trame.ui.vuetify3 import SinglePageLayout
 
 from paraview import simple
@@ -45,8 +45,8 @@ with SinglePageLayout(server) as layout:
     layout.title.set_text("Cone Application")
 
     with layout.toolbar:
-        vuetify3.VSpacer()
-        vuetify3.VSlider(
+        vuetify.VSpacer()
+        vuetify.VSlider(
             v_model=("resolution", DEFAULT_RESOLUTION),
             min=3,
             max=60,
@@ -55,12 +55,12 @@ with SinglePageLayout(server) as layout:
             dense=True,
             style="max-width: 300px",
         )
-        vuetify3.VDivider(vertical=True, classes="mx-2")
-        with vuetify3.VBtn(icon=True, click=update_reset_resolution):
-            vuetify3.VIcon("mdi-undo-variant")
+        vuetify.VDivider(vertical=True, classes="mx-2")
+        with vuetify.VBtn(icon=True, click=update_reset_resolution):
+            vuetify.VIcon("mdi-undo-variant")
 
     with layout.content:
-        with vuetify3.VContainer(
+        with vuetify.VContainer(
             fluid=True,
             classes="pa-0 fill-height",
         ):

--- a/05_paraview/SimpleCone.py
+++ b/05_paraview/SimpleCone.py
@@ -1,8 +1,8 @@
-import paraview.web.venv  # Available in PV 5.10
-
-from trame.app import get_server
-from trame.widgets import vuetify3, paraview
+from trame.app import TrameApp
 from trame.ui.vuetify3 import SinglePageLayout
+from trame.widgets import vuetify3 as v3
+from trame.widgets import paraview
+from trame.decorators import change
 
 from paraview import simple
 
@@ -10,68 +10,77 @@ from paraview import simple
 # trame setup
 # -----------------------------------------------------------------------------
 
-server = get_server()
-state, ctrl = server.state, server.controller
+class ConeApp(TrameApp):
+    def __init__(self, server=None):   
+        super().__init__(server)
+        self._init_paraview()
+        self._build_ui()
 
 # -----------------------------------------------------------------------------
 # ParaView code
 # -----------------------------------------------------------------------------
 
-DEFAULT_RESOLUTION = 6
+    def _init_paraview(self):
+        self.DEFAULT_RESOLUTION = 6
 
-cone = simple.Cone()
-representation = simple.Show(cone)
-view = simple.Render()
-
-
-@state.change("resolution")
-def update_cone(resolution, **kwargs):
-    cone.Resolution = resolution
-    ctrl.view_update()
+        self.cone = simple.Cone()
+        self.representation = simple.Show(self.cone)
+        self.view = simple.Render()
 
 
-def update_reset_resolution():
-    state.resolution = DEFAULT_RESOLUTION
+    @change("resolution")
+    def update_cone(self, resolution, **kwargs):
+        self.cone.Resolution = resolution
+        self.ctrl.view_update()
+
+
+    def update_reset_resolution(self):
+        self.state.resolution = self.DEFAULT_RESOLUTION
 
 
 # -----------------------------------------------------------------------------
 # GUI
 # -----------------------------------------------------------------------------
 
-state.trame__title = "ParaView cone"
+    def _build_ui(self):
+        self.state.trame__title = "ParaView cone"
 
-with SinglePageLayout(server) as layout:
-    layout.icon.click = ctrl.view_reset_camera
-    layout.title.set_text("Cone Application")
+        with SinglePageLayout(self.server) as self.ui:
+            self.ui.icon.click = self.ctrl.view_reset_camera
+            self.ui.title.set_text("Cone Application")
 
-    with layout.toolbar:
-        vuetify3.VSpacer()
-        vuetify3.VSlider(
-            v_model=("resolution", DEFAULT_RESOLUTION),
-            min=3,
-            max=60,
-            step=1,
-            hide_details=True,
-            dense=True,
-            style="max-width: 300px",
-        )
-        vuetify3.VDivider(vertical=True, classes="mx-2")
-        with vuetify3.VBtn(icon=True, click=update_reset_resolution):
-            vuetify3.VIcon("mdi-undo-variant")
+            with self.ui.toolbar:
+                v3.VSpacer()
+                v3.VSlider(
+                    v_model=("resolution", self.DEFAULT_RESOLUTION),
+                    min=3,
+                    max=60,
+                    step=1,
+                    hide_details=True,
+                    dense=True,
+                    style="max-width: 300px",
+                )
+                v3.VDivider(vertical=True, classes="mx-2")
+                with v3.VBtn(icon=True, click=self.update_reset_resolution):
+                    v3.VIcon("mdi-undo-variant")
 
-    with layout.content:
-        with vuetify3.VContainer(
-            fluid=True,
-            classes="pa-0 fill-height",
-        ):
-            html_view = paraview.VtkRemoteView(view)
-            # html_view = paraview.VtkLocalView(view)
-            ctrl.view_update = html_view.update
-            ctrl.view_reset_camera = html_view.reset_camera
+            with self.ui.content:
+                with v3.VContainer(
+                    fluid=True,
+                    classes="pa-0 fill-height",
+                ):
+                    html_view = paraview.VtkRemoteView(self.view)
+                    # html_view = paraview.VtkLocalView(view)
+                    self.ctrl.view_update = html_view.update
+                    self.ctrl.view_reset_camera = html_view.reset_camera
 
 # -----------------------------------------------------------------------------
 # Main
 # -----------------------------------------------------------------------------
 
+def main():
+    app = ConeApp()
+    app.server.start()
+
 if __name__ == "__main__":
-    server.start()
+    main()

--- a/05_paraview/SimpleCone.py
+++ b/05_paraview/SimpleCone.py
@@ -57,7 +57,7 @@ class ConeApp(TrameApp):
                     max=60,
                     step=1,
                     hide_details=True,
-                    dense=True,
+                    density="compact",
                     style="max-width: 300px",
                 )
                 v3.VDivider(vertical=True, classes="mx-2")

--- a/05_paraview/SimpleCone.py
+++ b/05_paraview/SimpleCone.py
@@ -1,7 +1,7 @@
 import paraview.web.venv  # Available in PV 5.10
 
 from trame.app import get_server
-from trame.widgets import vuetify3 as vuetify, paraview
+from trame.widgets import vuetify3, paraview
 from trame.ui.vuetify3 import SinglePageLayout
 
 from paraview import simple
@@ -45,8 +45,8 @@ with SinglePageLayout(server) as layout:
     layout.title.set_text("Cone Application")
 
     with layout.toolbar:
-        vuetify.VSpacer()
-        vuetify.VSlider(
+        vuetify3.VSpacer()
+        vuetify3.VSlider(
             v_model=("resolution", DEFAULT_RESOLUTION),
             min=3,
             max=60,
@@ -55,12 +55,12 @@ with SinglePageLayout(server) as layout:
             dense=True,
             style="max-width: 300px",
         )
-        vuetify.VDivider(vertical=True, classes="mx-2")
-        with vuetify.VBtn(icon=True, click=update_reset_resolution):
-            vuetify.VIcon("mdi-undo-variant")
+        vuetify3.VDivider(vertical=True, classes="mx-2")
+        with vuetify3.VBtn(icon=True, click=update_reset_resolution):
+            vuetify3.VIcon("mdi-undo-variant")
 
     with layout.content:
-        with vuetify.VContainer(
+        with vuetify3.VContainer(
             fluid=True,
             classes="pa-0 fill-height",
         ):

--- a/05_paraview/SimpleCone.py
+++ b/05_paraview/SimpleCone.py
@@ -29,7 +29,7 @@ class ConeApp(TrameApp):
 
 
     @change("resolution")
-    def update_cone(self, resolution, **kwargs):
+    def update_cone(self, resolution, **_kwargs):
         self.cone.Resolution = resolution
         self.ctrl.view_update()
 

--- a/05_paraview/SimpleCone.py
+++ b/05_paraview/SimpleCone.py
@@ -1,8 +1,8 @@
 import paraview.web.venv  # Available in PV 5.10
 
 from trame.app import get_server
-from trame.widgets import vuetify, paraview
-from trame.ui.vuetify import SinglePageLayout
+from trame.widgets import vuetify3, paraview
+from trame.ui.vuetify3 import SinglePageLayout
 
 from paraview import simple
 
@@ -10,7 +10,7 @@ from paraview import simple
 # trame setup
 # -----------------------------------------------------------------------------
 
-server = get_server(client_type = "vue2")
+server = get_server()
 state, ctrl = server.state, server.controller
 
 # -----------------------------------------------------------------------------
@@ -45,8 +45,8 @@ with SinglePageLayout(server) as layout:
     layout.title.set_text("Cone Application")
 
     with layout.toolbar:
-        vuetify.VSpacer()
-        vuetify.VSlider(
+        vuetify3.VSpacer()
+        vuetify3.VSlider(
             v_model=("resolution", DEFAULT_RESOLUTION),
             min=3,
             max=60,
@@ -55,12 +55,12 @@ with SinglePageLayout(server) as layout:
             dense=True,
             style="max-width: 300px",
         )
-        vuetify.VDivider(vertical=True, classes="mx-2")
-        with vuetify.VBtn(icon=True, click=update_reset_resolution):
-            vuetify.VIcon("mdi-undo-variant")
+        vuetify3.VDivider(vertical=True, classes="mx-2")
+        with vuetify3.VBtn(icon=True, click=update_reset_resolution):
+            vuetify3.VIcon("mdi-undo-variant")
 
     with layout.content:
-        with vuetify.VContainer(
+        with vuetify3.VContainer(
             fluid=True,
             classes="pa-0 fill-height",
         ):

--- a/05_paraview/SimpleCone.py
+++ b/05_paraview/SimpleCone.py
@@ -13,6 +13,9 @@ from paraview import simple
 class ConeApp(TrameApp):
     def __init__(self, server=None):   
         super().__init__(server)
+
+        self.DEFAULT_RESOLUTION = 6
+
         self._init_paraview()
         self._build_ui()
 
@@ -21,8 +24,6 @@ class ConeApp(TrameApp):
 # -----------------------------------------------------------------------------
 
     def _init_paraview(self):
-        self.DEFAULT_RESOLUTION = 6
-
         self.cone = simple.Cone()
         self.representation = simple.Show(self.cone)
         self.view = simple.Render()
@@ -61,8 +62,7 @@ class ConeApp(TrameApp):
                     style="max-width: 300px",
                 )
                 v3.VDivider(vertical=True, classes="mx-2")
-                with v3.VBtn(icon=True, click=self.update_reset_resolution):
-                    v3.VIcon("mdi-undo-variant")
+                v3.VBtn(icon="mdi-undo-variant", click=self.update_reset_resolution)
 
             with self.ui.content:
                 with v3.VContainer(

--- a/05_paraview/StateLoader.py
+++ b/05_paraview/StateLoader.py
@@ -1,4 +1,4 @@
-from paraview.web import venv  # Available in PV 5.10-RC2+
+from paraview.web import venv
 from paraview import simple
 
 from pathlib import Path

--- a/05_paraview/StateLoader.py
+++ b/05_paraview/StateLoader.py
@@ -2,7 +2,6 @@ from trame.app import TrameApp
 from trame.ui.vuetify3 import SinglePageLayout
 from trame.widgets import vuetify3 as v3
 from trame.widgets import paraview, client
-from trame.decorators import change
 
 from pathlib import Path
 
@@ -16,9 +15,13 @@ class StateLoaderApp(TrameApp):
 
     def __init__(self, server=None):
         super().__init__(server)
+        self.server.cli.add_argument("--data", help="Path to state file", dest="data")
 
         # Preload paraview modules onto server
         paraview.initialize(self.server)
+
+        self.ctrl.on_server_ready.add(self.load_data)
+        self._build_ui()
 
 
 # -----------------------------------------------------------------------------
@@ -26,7 +29,7 @@ class StateLoaderApp(TrameApp):
 # -----------------------------------------------------------------------------
 
 
-    def load_data(self, **kwargs):
+    def load_data(self, **_kwargs):
         # CLI
         args, _ = self.server.cli.parse_known_args()
 
@@ -44,18 +47,15 @@ class StateLoaderApp(TrameApp):
         simple.Render(self.view)
 
         # HTML
-        with SinglePageLayout(self.server) as layout:
-            layout.icon.click = self.ctrl.view_reset_camera
-            layout.title.set_text("ParaView State Viewer")
+        with SinglePageLayout(self.server) as self.ui:
+            self.ui.icon.click = self.ctrl.view_reset_camera
+            self.ui.title.set_text("ParaView State Viewer")
 
-            with layout.content:
+            with self.ui.content:
                 with v3.VContainer(fluid=True, classes="pa-0 fill-height"):
                     html_view = paraview.VtkRemoteView(self.view)
                     self.ctrl.view_reset_camera = html_view.reset_camera
-                    self.ctrl.view_update = html_view.update
-
-
-        self.ctrl.on_server_ready.add(self.load_data)
+                    self.ctrl.view_update = html_view.update 
 
 # -----------------------------------------------------------------------------
 # GUI
@@ -69,7 +69,7 @@ class StateLoaderApp(TrameApp):
             self.ui.title.set_text("ParaView State Viewer")
 
             with self.ui.content:
-                with self.vuetify3.VContainer(fluid=True, classes="pa-0 fill-height"):
+                with v3.VContainer(fluid=True, classes="pa-0 fill-height"):
                     client.Loading("Loading state")
 
 

--- a/05_paraview/StateLoader.py
+++ b/05_paraview/StateLoader.py
@@ -3,14 +3,14 @@ from paraview import simple
 
 from pathlib import Path
 from trame.app import get_server
-from trame.widgets import vuetify, paraview, client
-from trame.ui.vuetify import SinglePageLayout
+from trame.widgets import vuetify3, paraview, client
+from trame.ui.vuetify3 import SinglePageLayout
 
 # -----------------------------------------------------------------------------
 # Trame setup
 # -----------------------------------------------------------------------------
 
-server = get_server(client_type = "vue2")
+server = get_server()
 state, ctrl = server.state, server.controller
 
 # Preload paraview modules onto server
@@ -44,7 +44,7 @@ def load_data(**kwargs):
         layout.title.set_text("ParaView State Viewer")
 
         with layout.content:
-            with vuetify.VContainer(fluid=True, classes="pa-0 fill-height"):
+            with vuetify3.VContainer(fluid=True, classes="pa-0 fill-height"):
                 html_view = paraview.VtkRemoteView(view)
                 ctrl.view_reset_camera = html_view.reset_camera
                 ctrl.view_update = html_view.update
@@ -63,7 +63,7 @@ with SinglePageLayout(server) as layout:
     layout.title.set_text("ParaView State Viewer")
 
     with layout.content:
-        with vuetify.VContainer(fluid=True, classes="pa-0 fill-height"):
+        with vuetify3.VContainer(fluid=True, classes="pa-0 fill-height"):
             client.Loading("Loading state")
 
 

--- a/05_paraview/StateLoader.py
+++ b/05_paraview/StateLoader.py
@@ -1,76 +1,85 @@
-from paraview.web import venv
-from paraview import simple
+from trame.app import TrameApp
+from trame.ui.vuetify3 import SinglePageLayout
+from trame.widgets import vuetify3 as v3
+from trame.widgets import paraview, client
+from trame.decorators import change
 
 from pathlib import Path
-from trame.app import get_server
-from trame.widgets import vuetify3, paraview, client
-from trame.ui.vuetify3 import SinglePageLayout
+
+from paraview import simple
 
 # -----------------------------------------------------------------------------
 # Trame setup
 # -----------------------------------------------------------------------------
 
-server = get_server()
-state, ctrl = server.state, server.controller
+class StateLoaderApp(TrameApp):
 
-# Preload paraview modules onto server
-paraview.initialize(server)
+    def __init__(self, server=None):
+        super().__init__(server)
+
+        # Preload paraview modules onto server
+        paraview.initialize(self.server)
+
 
 # -----------------------------------------------------------------------------
 # ParaView code
 # -----------------------------------------------------------------------------
 
 
-def load_data(**kwargs):
-    # CLI
-    args, _ = server.cli.parse_known_args()
+    def load_data(self, **kwargs):
+        # CLI
+        args, _ = self.server.cli.parse_known_args()
 
-    full_path = str(Path(args.data).resolve().absolute())
-    working_directory = str(Path(args.data).parent.resolve().absolute())
+        full_path = str(Path(args.data).resolve().absolute())
+        working_directory = str(Path(args.data).parent.resolve().absolute())
 
-    # ParaView
-    simple.LoadState(
-        full_path,
-        data_directory=working_directory,
-        restrict_to_data_directory=True,
-    )
-    view = simple.GetActiveView()
-    view.MakeRenderWindowInteractor(True)
-    simple.Render(view)
+        # ParaView
+        simple.LoadState(
+            full_path,
+            data_directory=working_directory,
+            restrict_to_data_directory=True,
+        )
+        self.view = simple.GetActiveView()
+        self.view.MakeRenderWindowInteractor(True)
+        simple.Render(self.view)
 
-    # HTML
-    with SinglePageLayout(server) as layout:
-        layout.icon.click = ctrl.view_reset_camera
-        layout.title.set_text("ParaView State Viewer")
+        # HTML
+        with SinglePageLayout(self.server) as layout:
+            layout.icon.click = self.ctrl.view_reset_camera
+            layout.title.set_text("ParaView State Viewer")
 
-        with layout.content:
-            with vuetify3.VContainer(fluid=True, classes="pa-0 fill-height"):
-                html_view = paraview.VtkRemoteView(view)
-                ctrl.view_reset_camera = html_view.reset_camera
-                ctrl.view_update = html_view.update
+            with layout.content:
+                with v3.VContainer(fluid=True, classes="pa-0 fill-height"):
+                    html_view = paraview.VtkRemoteView(self.view)
+                    self.ctrl.view_reset_camera = html_view.reset_camera
+                    self.ctrl.view_update = html_view.update
 
 
-ctrl.on_server_ready.add(load_data)
+        self.ctrl.on_server_ready.add(self.load_data)
 
 # -----------------------------------------------------------------------------
 # GUI
 # -----------------------------------------------------------------------------
 
-state.trame__title = "State Viewer"
+    def _build_ui(self):
+        self.state.trame__title = "State Viewer"
 
-with SinglePageLayout(server) as layout:
-    layout.icon.click = ctrl.view_reset_camera
-    layout.title.set_text("ParaView State Viewer")
+        with SinglePageLayout(self.server) as self.ui:
+            self.ui.icon.click = self.ctrl.view_reset_camera
+            self.ui.title.set_text("ParaView State Viewer")
 
-    with layout.content:
-        with vuetify3.VContainer(fluid=True, classes="pa-0 fill-height"):
-            client.Loading("Loading state")
+            with self.ui.content:
+                with self.vuetify3.VContainer(fluid=True, classes="pa-0 fill-height"):
+                    client.Loading("Loading state")
 
 
 # -----------------------------------------------------------------------------
 # Main
 # -----------------------------------------------------------------------------
 
+def main():
+    app = StateLoaderApp()
+    app.server.start()
+
 if __name__ == "__main__":
-    server.cli.add_argument("--data", help="Path to state file", dest="data")
-    server.start()
+    main()


### PR DESCRIPTION
This PR depends on https://github.com/Kitware/trame/pull/877
because trame and trame-tutorial are referencing one another.

Upgrade the tutorial examples from Vue2 to Vue3.
- Change vuetify to vuetify3 in the code
- Change VSelect's items' text and value
- Change toggle dark theme mechanism